### PR TITLE
Hydrate geotag from index

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <scala.version>2.13.8</scala.version>
-        <elastic4s.version>7.16.1</elastic4s.version>
+        <elastic4s.version>7.17.4</elastic4s.version>
         <jackson.version>2.13.3</jackson.version>
     </properties>
 

--- a/src/main/scala/nz/co/searchwellington/repositories/ContentRetrievalService.scala
+++ b/src/main/scala/nz/co/searchwellington/repositories/ContentRetrievalService.scala
@@ -418,12 +418,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
         val eventualHandTags = loadTags(r.resource_tags.map(_.tag_id).distinct)
         val eventualIndexTags = loadTags(elasticResourcesById.get(r._id).map(_.indexTags).getOrElse(Seq.empty))
-        val eventualGeocode = indexTagsService.getIndexGeocodeForResource(r)  // TODO persist in index for faster rendering
+        val maybeGeocode = elasticResourcesById.get(r._id).flatMap(er => er.geocode)
+
         eventualHandTags.flatMap { handTags =>
           eventualIndexTags.flatMap { indexTags =>
-            eventualGeocode.flatMap { geocode =>
-              frontendResourceMapper.createFrontendResourceFrom(r, loggedInUser, geocode, handTags, indexTags)
-            }
+            frontendResourceMapper.createFrontendResourceFrom(r, loggedInUser, maybeGeocode, handTags, indexTags)
           }
         }
 

--- a/src/main/scala/nz/co/searchwellington/repositories/ContentRetrievalService.scala
+++ b/src/main/scala/nz/co/searchwellington/repositories/ContentRetrievalService.scala
@@ -418,8 +418,9 @@ import scala.concurrent.{ExecutionContext, Future}
 
         val eventualHandTags = loadTags(r.resource_tags.map(_.tag_id).distinct)
         val eventualIndexTags = loadTags(elasticResourcesById.get(r._id).map(_.indexTags).getOrElse(Seq.empty))
-        val maybeGeocode = elasticResourcesById.get(r._id).flatMap(er => er.geocode)
-
+        val maybeResource = elasticResourcesById.get(r._id)
+        val maybeGeocode = maybeResource.flatMap(er => er.geocode)
+        log.info("Resource " + r._id.stringify + " mapped to ES resource: " + maybeResource + " and geocode " + maybeGeocode)
         eventualHandTags.flatMap { handTags =>
           eventualIndexTags.flatMap { indexTags =>
             frontendResourceMapper.createFrontendResourceFrom(r, loggedInUser, maybeGeocode, handTags, indexTags)

--- a/src/main/scala/nz/co/searchwellington/repositories/ContentRetrievalService.scala
+++ b/src/main/scala/nz/co/searchwellington/repositories/ContentRetrievalService.scala
@@ -420,7 +420,6 @@ import scala.concurrent.{ExecutionContext, Future}
         val eventualIndexTags = loadTags(elasticResourcesById.get(r._id).map(_.indexTags).getOrElse(Seq.empty))
         val maybeResource = elasticResourcesById.get(r._id)
         val maybeGeocode = maybeResource.flatMap(er => er.geocode)
-        log.info("Resource " + r._id.stringify + " mapped to ES resource: " + maybeResource + " and geocode " + maybeGeocode)
         eventualHandTags.flatMap { handTags =>
           eventualIndexTags.flatMap { indexTags =>
             frontendResourceMapper.createFrontendResourceFrom(r, loggedInUser, maybeGeocode, handTags, indexTags)

--- a/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticFields.scala
+++ b/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticFields.scala
@@ -20,5 +20,6 @@ trait ElasticFields {
   val LastChanged = "last_changed"
   val Hostname = "hostname"
   val AcceptedDate = "accepted"
+  val GeotagVote = "geotagVote"
 
 }

--- a/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticSearchIndexer.scala
+++ b/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticSearchIndexer.scala
@@ -85,7 +85,9 @@ class ElasticSearchIndexer @Autowired()(val showBrokenDecisionService: ShowBroke
             keywordField(Hostname),
             dateField(AcceptedDate),
             objectField(GeotagVote).copy(properties = Seq(
+              textField(Description).index(false),
               geopointField(LatLong),
+              keywordField("osmId")
             ))
           ))
         }

--- a/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticSearchIndexer.scala
+++ b/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticSearchIndexer.scala
@@ -85,7 +85,7 @@ class ElasticSearchIndexer @Autowired()(val showBrokenDecisionService: ShowBroke
             keywordField(Hostname),
             dateField(AcceptedDate),
             objectField(GeotagVote).copy(properties = Seq(
-              textField(Description).index(false),
+              textField("address").index(false),
               geopointField(LatLong),
               keywordField("osmId")
             ))

--- a/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticSearchIndexer.scala
+++ b/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticSearchIndexer.scala
@@ -192,10 +192,13 @@ class ElasticSearchIndexer @Autowired()(val showBrokenDecisionService: ShowBroke
           val handTags = h.sourceAsMap.get(HandTags).asInstanceOf[Option[List[String]]].map(_.flatMap(tid => BSONObjectID.parse(tid).toOption)).getOrElse(Seq.empty)
           val indexTags = h.sourceAsMap.get(Tags).asInstanceOf[Option[List[String]]].map(_.flatMap(tid => BSONObjectID.parse(tid).toOption)).getOrElse(Seq.empty)
 
-          val geotagVoteFields: Option[Map[String, Object]] = h.sourceAsMap.get(GeotagVote).asInstanceOf[Option[Map[String, Object]]]
-          val geocode: Option[Geocode] = geotagVoteFields.map { fields =>
-            Geocode(address = fields.get("address").map(_.asInstanceOf[String]))
+          // Hydrate geotag from nested object fields; there must be a more direct way of doing this?
+          val geotagVoteFields = h.sourceAsMap.get(GeotagVote).asInstanceOf[Option[Map[String, Object]]]
+          val geocode = geotagVoteFields.map { fields =>
+            val maybeAddress = fields.get("address")
+            Geocode(address = maybeAddress.map(_.asInstanceOf[String]))
           }
+
           ElasticResource(bid, handTags, indexTags, geocode)
         }
       }

--- a/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticSearchIndexer.scala
+++ b/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticSearchIndexer.scala
@@ -83,7 +83,7 @@ class ElasticSearchIndexer @Autowired()(val showBrokenDecisionService: ShowBroke
             keywordField(Hostname),
             dateField(AcceptedDate),
             objectField(GeotagVote).copy(properties = Seq(
-              textField("address"),  // TODO doesn't need to be indexed; just round tripped
+              keywordField("address"),  // TODO doesn't need to be indexed; just round tripped
               geopointField(LatLong),
               keywordField("osmId")
             ))

--- a/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticSearchIndexer.scala
+++ b/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticSearchIndexer.scala
@@ -83,7 +83,6 @@ class ElasticSearchIndexer @Autowired()(val showBrokenDecisionService: ShowBroke
             keywordField(Hostname),
             dateField(AcceptedDate),
             objectField(GeotagVote).copy(properties = Seq(
-              keywordField("address"),  // TODO doesn't need to be indexed; just round tripped
               geopointField(LatLong),
               keywordField("osmId")
             ))

--- a/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticSearchIndexer.scala
+++ b/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticSearchIndexer.scala
@@ -155,7 +155,7 @@ class ElasticSearchIndexer @Autowired()(val showBrokenDecisionService: ShowBroke
         resource.last_changed.map(lc => LastChanged -> new DateTime(lc)),
         indexResource.hostname.map(u => Hostname -> u),
         accepted.map(a => AcceptedDate -> new DateTime(a)),
-        resource.geocode.map ( g => {
+        indexResource.geocode.map ( g => {
           val geotagVoteFields = Seq(
             g.address.map("address" -> _),
             latLong.map(ll => LatLong -> Map("lat" -> ll.getLatitude, "lon" -> ll.getLongitude)),

--- a/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticSearchIndexer.scala
+++ b/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticSearchIndexer.scala
@@ -137,7 +137,7 @@ class ElasticSearchIndexer @Autowired()(val showBrokenDecisionService: ShowBroke
 
       val latLong = indexResource.geocode.flatMap(_.latLong)
 
-      val fields: Seq[Option[(String, Any)]] = Seq(
+      val fields = Seq(
         Some(Type -> resource.`type`),
         Some(Title -> resource.title),
         Some(TitleSort -> resource.title),

--- a/src/test/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticSearchIndexerTest.scala
+++ b/src/test/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticSearchIndexerTest.scala
@@ -244,7 +244,7 @@ class ElasticSearchIndexerTest extends IndexableResource with ReasonableWaits {
     assertFalse(result.result.errors)
 
     def geocodedNewsitems = {
-      Await.result(elasticSearchIndexer.getResources(ResourceQuery(`type` = Some(Set("N"))), loggedInUser = Some(loggedInUser)), TenSeconds)
+      Await.result(elasticSearchIndexer.getResources(ResourceQuery(`type` = Some(Set("N")), geocoded = Some(true)), loggedInUser = Some(loggedInUser)), TenSeconds)
     }
     eventually(timeout(TenSeconds), interval(TenMilliSeconds))(geocodedNewsitems._1.map(_._id).contains(geotagged._id) mustBe true)
     val roundTrippedGeocode = geocodedNewsitems._1.head.geocode

--- a/src/test/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticSearchIndexerTest.scala
+++ b/src/test/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticSearchIndexerTest.scala
@@ -244,10 +244,10 @@ class ElasticSearchIndexerTest extends IndexableResource with ReasonableWaits {
     assertFalse(result.result.errors)
 
     def geocodedNewsitems = {
-      queryForResources(ResourceQuery(`type` = Some(Set("N"))))
+      Await.result(elasticSearchIndexer.getResources(ResourceQuery(`type` = Some(Set("N"))), loggedInUser = Some(loggedInUser)), TenSeconds)
     }
-    eventually(timeout(TenSeconds), interval(TenMilliSeconds))(geocodedNewsitems.contains(geotagged) mustBe true)
-    val roundTrippedGeocode = geocodedNewsitems.head.geocode
+    eventually(timeout(TenSeconds), interval(TenMilliSeconds))(geocodedNewsitems._1.map(_._id).contains(geotagged._id) mustBe true)
+    val roundTrippedGeocode = geocodedNewsitems._1.head.geocode
     assertEquals(Some(geocode), roundTrippedGeocode)
   }
 

--- a/wellynews.iml
+++ b/wellynews.iml
@@ -102,11 +102,11 @@
     <orderEntry type="library" name="Maven: org.jdom:jdom2:2.0.6.1" level="project" />
     <orderEntry type="library" name="Maven: com.rometools:rome-modules:1.18.0" level="project" />
     <orderEntry type="library" name="Maven: com.rometools:rome-utils:1.18.0" level="project" />
-    <orderEntry type="library" name="Maven: uk.co.eelpieconsulting.common:common-shorturls:1.1.5" level="project" />
+    <orderEntry type="library" name="Maven: uk.co.eelpieconsulting.common:common-shorturls:1.1.6" level="project" />
     <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpclient:4.5.13" level="project" />
     <orderEntry type="library" name="Maven: commons-logging:commons-logging:1.2" level="project" />
     <orderEntry type="library" name="Maven: uk.co.eelpieconsulting.common:common-dates:1.0.11" level="project" />
-    <orderEntry type="library" name="Maven: uk.co.eelpieconsulting.common:common-html:1.0.1" level="project" />
+    <orderEntry type="library" name="Maven: uk.co.eelpieconsulting.common:common-html:1.0.2" level="project" />
     <orderEntry type="library" name="Maven: org.apache.commons:commons-lang3:3.12.0" level="project" />
     <orderEntry type="library" name="Maven: uk.co.eelpieconsulting.common:common-geo:1.1.2" level="project" />
     <orderEntry type="library" name="Maven: fr.dudie:nominatim-api:3.0.1" level="project" />
@@ -114,7 +114,7 @@
     <orderEntry type="library" name="Maven: org.locationtech.spatial4j:spatial4j:0.8" level="project" />
     <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-api:2.17.2" level="project" />
     <orderEntry type="library" name="Maven: uk.co.eelpieconsulting.common:common-geo-model:1.0.4" level="project" />
-    <orderEntry type="library" name="Maven: uk.co.eelpieconsulting.common:common-caching:1.1.4" level="project" />
+    <orderEntry type="library" name="Maven: uk.co.eelpieconsulting.common:common-caching:1.1.5" level="project" />
     <orderEntry type="library" name="Maven: net.spy:spymemcached:2.12.3" level="project" />
     <orderEntry type="library" name="Maven: org.twitter4j:twitter4j-core:4.0.7" level="project" />
     <orderEntry type="library" name="Maven: com.google.guava:guava:31.1-jre" level="project" />


### PR DESCRIPTION
Write the outcome of the resource geotag vote into the elastic index. On view hydrate the geo information from the index rather than calling geotag vote inline. Same N mongo looks ups.

Seems to be worth ~ 30% page view improvement.

Make geo queries to run against the geotag vote nested object to help bake in the idea that the geo location is comes from the voting process, not just an explict field one the resources.