### PR TITLE
Better watchlist content diffing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,13 @@ Newsitems accepted from this feed will be attributed to this feed's publisher.
 
 ### Watchlist
 
-A page on a publishers website which is known to contain links to new newsitems.
+A page on a publishers website which is known to contain links to new news items.
 This might be a homepage or a news page.
 
-Used when a publisher with interesting content does not provide a feed.
+Watchlist items are used when a publisher with interesting content does not provide a feed 
+but their content is valuable enough to post manually.
 
-Polled regularly to detect changes which might indicate new newsitems.
+Watchlist items are polled regularly to detect changes which might indicate new news items.
 See detecting page changes (below)[(#detecting-changes)].
 
 
@@ -133,8 +134,8 @@ An item with a category of 'events' will be matched to the tag Events.
 Changes in pages can be detected by periodically downloading and checking them.
 Changes in content checksums indicate potential new content.
 
-Pages often contain elements such as timestamps which mean a pages checksum changes even if contains no new content.
-This should be filtered out before checksum pages.
+Pages often contain elements such as timestamps which make page's checksum unstable even if contains no new content.
+Only comparing the plain text content of a page helps to reduce these false positives.
 
 
 ### Accepted feed items view

--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.16.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <version>${jackson.version}</version>

--- a/src/main/scala/nz/co/searchwellington/linkchecking/PageContentHasher.scala
+++ b/src/main/scala/nz/co/searchwellington/linkchecking/PageContentHasher.scala
@@ -1,5 +1,6 @@
 package nz.co.searchwellington.linkchecking
 
+import org.jsoup.Jsoup
 import org.springframework.stereotype.Component
 import org.springframework.util.DigestUtils
 import uk.co.eelpieconsulting.common.html.HtmlCleaner
@@ -10,8 +11,8 @@ class PageContentHasher {
   private val htmlCleaner = new HtmlCleaner
 
   def hashPageContent(pageContent: String): String = {
-    // TODO cleaning and filtering?
-    DigestUtils.md5DigestAsHex(htmlCleaner.stripHtml(pageContent).getBytes())
-    }
+    val pageText = Jsoup.parse(pageContent).text()
+    DigestUtils.md5DigestAsHex(pageText.getBytes())
+  }
 
 }

--- a/src/test/resources/urbandreambrokerage_1.html
+++ b/src/test/resources/urbandreambrokerage_1.html
@@ -1,0 +1,10938 @@
+<!doctype html>
+<html xmlns:og="http://opengraphprotocol.org/schema/" xmlns:fb="http://www.facebook.com/2008/fbml" lang="en-US" >
+
+<head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  
+  <!-- This is Squarespace. --><!-- urbandreambrokerage -->
+<base href="">
+<meta charset="utf-8" />
+<title>Home &mdash; Urban Dream Brokerage</title>
+<meta http-equiv="Accept-CH" content="Sec-CH-UA-Platform-Version, Sec-CH-UA-Model" /><link rel="shortcut icon" type="image/x-icon" href="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1606292574122-SIWT4ES8XRH7GGCJQ7IR/favicon.ico?format=100w"/>
+<link rel="canonical" href="https://www.urbandreambrokerage.org.nz/home"/>
+<meta property="og:site_name" content="Urban Dream Brokerage"/>
+<meta property="og:title" content="Home &mdash; Urban Dream Brokerage"/>
+<meta property="og:url" content="https://www.urbandreambrokerage.org.nz/home"/>
+<meta property="og:type" content="website"/>
+<meta property="og:image" content="http://static1.squarespace.com/static/508a094ee4b0f50834e1e3d6/t/60bc7b8afd0e6f20d8fb2b35/1622965130730/Logo_Hero.jpg?format=1500w"/>
+<meta property="og:image:width" content="1500"/>
+<meta property="og:image:height" content="1000"/>
+<meta itemprop="name" content="Home — Urban Dream Brokerage"/>
+<meta itemprop="url" content="https://www.urbandreambrokerage.org.nz/home"/>
+<meta itemprop="thumbnailUrl" content="http://static1.squarespace.com/static/508a094ee4b0f50834e1e3d6/t/60bc7b8afd0e6f20d8fb2b35/1622965130730/Logo_Hero.jpg?format=1500w"/>
+<link rel="image_src" href="http://static1.squarespace.com/static/508a094ee4b0f50834e1e3d6/t/60bc7b8afd0e6f20d8fb2b35/1622965130730/Logo_Hero.jpg?format=1500w" />
+<meta itemprop="image" content="http://static1.squarespace.com/static/508a094ee4b0f50834e1e3d6/t/60bc7b8afd0e6f20d8fb2b35/1622965130730/Logo_Hero.jpg?format=1500w"/>
+<meta name="twitter:title" content="Home — Urban Dream Brokerage"/>
+<meta name="twitter:image" content="http://static1.squarespace.com/static/508a094ee4b0f50834e1e3d6/t/60bc7b8afd0e6f20d8fb2b35/1622965130730/Logo_Hero.jpg?format=1500w"/>
+<meta name="twitter:url" content="https://www.urbandreambrokerage.org.nz/home"/>
+<meta name="twitter:card" content="summary"/>
+<meta name="description" content="" />
+<link rel="preconnect" href="https://images.squarespace-cdn.com">
+<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Varela+Round:wght@400">
+<script type="text/javascript" crossorigin="anonymous" nomodule="nomodule" src="//assets.squarespace.com/@sqs/polyfiller/1.6/legacy.js"></script>
+<script type="text/javascript" crossorigin="anonymous" src="//assets.squarespace.com/@sqs/polyfiller/1.6/modern.js"></script>
+<script type="text/javascript">SQUARESPACE_ROLLUPS = {};</script>
+<script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/extract-css-runtime-43c685532b94daea7dd47-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-extract_css_runtime');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/extract-css-runtime-43c685532b94daea7dd47-min.en-US.js" ></script><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/extract-css-moment-js-vendor-5082e2dab696b020ac83a-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-extract_css_moment_js_vendor');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/extract-css-moment-js-vendor-5082e2dab696b020ac83a-min.en-US.js" ></script><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/cldr-resource-pack-bdc20c1f20167de1fe7a8-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-cldr_resource_pack');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/cldr-resource-pack-bdc20c1f20167de1fe7a8-min.en-US.js" ></script><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/common-vendors-stable-ded59447778e1491d87fa-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-common_vendors_stable');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/common-vendors-stable-ded59447778e1491d87fa-min.en-US.js" ></script><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/common-vendors-b986c312866d5bb96300a-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-common_vendors');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/common-vendors-b986c312866d5bb96300a-min.en-US.js" ></script><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/common-863c2f39a62780b7c9a01-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-common');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/common-863c2f39a62780b7c9a01-min.en-US.js" ></script><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/commerce-436b954374ed7e1b64691-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-commerce');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/commerce-436b954374ed7e1b64691-min.en-US.js" ></script><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].css = ["//assets.squarespace.com/universal/styles-compressed/commerce-42e904b2189a7c1684dd6-min.en-US.css"]; })(SQUARESPACE_ROLLUPS, 'squarespace-commerce');</script>
+<link rel="stylesheet" type="text/css" href="//assets.squarespace.com/universal/styles-compressed/commerce-42e904b2189a7c1684dd6-min.en-US.css"><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/performance-e800919c4e9695235b048-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-performance');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/performance-e800919c4e9695235b048-min.en-US.js" defer ></script><script data-name="static-context">Static = window.Static || {}; Static.SQUARESPACE_CONTEXT = {"facebookAppId":"314192535267336","facebookApiVersion":"v6.0","rollups":{"squarespace-announcement-bar":{"js":"//assets.squarespace.com/universal/scripts-compressed/announcement-bar-e41a5a6174c4379a36699-min.en-US.js"},"squarespace-audio-player":{"css":"//assets.squarespace.com/universal/styles-compressed/audio-player-702bf18174efe0acaa8ce-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/audio-player-d7b6f0fff199ccaec2f12-min.en-US.js"},"squarespace-blog-collection-list":{"css":"//assets.squarespace.com/universal/styles-compressed/blog-collection-list-3d55c64c25996c7633fc2-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/blog-collection-list-94d73863f597285f58c6a-min.en-US.js"},"squarespace-calendar-block-renderer":{"css":"//assets.squarespace.com/universal/styles-compressed/calendar-block-renderer-49c4a5f3dae67a728e3f4-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/calendar-block-renderer-cdc255d3aa9010e5e39c8-min.en-US.js"},"squarespace-chartjs-helpers":{"css":"//assets.squarespace.com/universal/styles-compressed/chartjs-helpers-53c004ac7d4bde1c92e38-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/chartjs-helpers-c74aad14bf44675c52a9b-min.en-US.js"},"squarespace-comments":{"css":"//assets.squarespace.com/universal/styles-compressed/comments-cb7553e34a4da425817c4-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/comments-5dd3488d8c6a268f12adc-min.en-US.js"},"squarespace-custom-css-popup":{"css":"//assets.squarespace.com/universal/styles-compressed/custom-css-popup-1364ee7f064caef6cd5e3-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/custom-css-popup-55944760d5354026e7fd6-min.en-US.js"},"squarespace-dialog":{"css":"//assets.squarespace.com/universal/styles-compressed/dialog-9d9d0e960227d34faac26-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/dialog-4fc035cca7461a9de2248-min.en-US.js"},"squarespace-events-collection":{"css":"//assets.squarespace.com/universal/styles-compressed/events-collection-49c4a5f3dae67a728e3f4-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/events-collection-f458105b5483abf402b94-min.en-US.js"},"squarespace-form-rendering-utils":{"js":"//assets.squarespace.com/universal/scripts-compressed/form-rendering-utils-0028541919bfa14316cd2-min.en-US.js"},"squarespace-forms":{"css":"//assets.squarespace.com/universal/styles-compressed/forms-4a16a8a8c965386db2173-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/forms-3a63dcf6f7bed3dc6c008-min.en-US.js"},"squarespace-gallery-collection-list":{"css":"//assets.squarespace.com/universal/styles-compressed/gallery-collection-list-3d55c64c25996c7633fc2-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/gallery-collection-list-80bfda88034d1e2f95767-min.en-US.js"},"squarespace-image-zoom":{"css":"//assets.squarespace.com/universal/styles-compressed/image-zoom-3d55c64c25996c7633fc2-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/image-zoom-b56ca0b7347a780ce9521-min.en-US.js"},"squarespace-pinterest":{"css":"//assets.squarespace.com/universal/styles-compressed/pinterest-3d55c64c25996c7633fc2-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/pinterest-5926f617ef8f50b51f24f-min.en-US.js"},"squarespace-popup-overlay":{"css":"//assets.squarespace.com/universal/styles-compressed/popup-overlay-948192219c3257f767ec5-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/popup-overlay-59e7d62405c35d1149741-min.en-US.js"},"squarespace-product-quick-view":{"css":"//assets.squarespace.com/universal/styles-compressed/product-quick-view-4a16a8a8c965386db2173-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/product-quick-view-8fc1ce427143734bc6dbe-min.en-US.js"},"squarespace-products-collection-item-v2":{"css":"//assets.squarespace.com/universal/styles-compressed/products-collection-item-v2-3d55c64c25996c7633fc2-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/products-collection-item-v2-6bc58c99783f0bbc14f30-min.en-US.js"},"squarespace-products-collection-list-v2":{"css":"//assets.squarespace.com/universal/styles-compressed/products-collection-list-v2-3d55c64c25996c7633fc2-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/products-collection-list-v2-239ed1ac3377d9ad03fd6-min.en-US.js"},"squarespace-search-page":{"css":"//assets.squarespace.com/universal/styles-compressed/search-page-9d0a55de1efafbb9218e1-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/search-page-8836bcf88581fa68e2715-min.en-US.js"},"squarespace-search-preview":{"js":"//assets.squarespace.com/universal/scripts-compressed/search-preview-7a592134ce0bc79cf8d2a-min.en-US.js"},"squarespace-simple-liking":{"css":"//assets.squarespace.com/universal/styles-compressed/simple-liking-ef94529873378652e6e86-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/simple-liking-fdae2d43d38af1cfe236b-min.en-US.js"},"squarespace-social-buttons":{"css":"//assets.squarespace.com/universal/styles-compressed/social-buttons-1f18e025ea682ade6293a-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/social-buttons-6cb97c441463bdafcb2a6-min.en-US.js"},"squarespace-tourdates":{"css":"//assets.squarespace.com/universal/styles-compressed/tourdates-3d55c64c25996c7633fc2-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/tourdates-71aff6dea00efb2ffc404-min.en-US.js"},"squarespace-website-overlays-manager":{"css":"//assets.squarespace.com/universal/styles-compressed/website-overlays-manager-7cecc648f858e6f692130-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/website-overlays-manager-0fc3751b5fee9d0f53699-min.en-US.js"}},"pageType":2,"website":{"id":"508a094ee4b0f50834e1e3d6","identifier":"urbandreambrokerage","websiteType":1,"contentModifiedOn":1685323414714,"cloneable":false,"hasBeenCloneable":false,"siteStatus":{},"language":"en-US","timeZone":"Pacific/Wake","machineTimeZoneOffset":43200000,"timeZoneOffset":43200000,"timeZoneAbbr":"WAKT","siteTitle":"Urban Dream Brokerage","fullSiteTitle":"Home \u2014 Urban Dream Brokerage","siteTagLine":"Space for new ideas in Wellington Te Whanganui \u0101 Tara","siteDescription":"<p>Nau mai Haere mai.&nbsp;<span>Urban Dream Brokerage provides space for new ideas in Wellington Te Whanganui </span>\u0101&nbsp;T<span>ara. Working with property managers, individuals and community groups UDB brokers the temporary use of vacant space for innovative projects, assisting in urban revitalisation. It is run by organisation</span><a target=\"_blank\" href=\"http://www.lettingspace.org.nz/\">&nbsp;</a><a target=\"_blank\" href=\"http://www.lettingspace.org.nz/\">Letting Space</a><span>.</span></p>","location":{"mapZoom":12.0,"mapLat":-41.2864603,"mapLng":174.77623600000004,"markerLat":-41.29521159999999,"markerLng":174.7801541,"addressTitle":"Urban Dream Brokerage","addressLine1":"Ground floor, 19 Tory Street","addressLine2":"Wellington city","addressCountry":"New Zealand"},"logoImageId":"6396af1a4be5de371da80152","socialLogoImageId":"60bc7b8afd0e6f20d8fb2b35","shareButtonOptions":{"4":true,"3":true,"8":true,"7":true,"6":true},"logoImageUrl":"//images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/e7e423b2-7ffb-490d-8d9c-8a8b9c2f8c21/UDB-Banner-116.png","socialLogoImageUrl":"//images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/567f5fc9-036c-4c3e-a281-5434e0435485/Logo_Hero.jpg","authenticUrl":"https://www.urbandreambrokerage.org.nz","internalUrl":"https://urbandreambrokerage.squarespace.com","baseUrl":"https://www.urbandreambrokerage.org.nz","primaryDomain":"www.urbandreambrokerage.org.nz","sslSetting":3,"isHstsEnabled":true,"socialAccounts":[{"serviceId":60,"screenname":"Facebook","addedOn":1682996435601,"profileUrl":"https://fb.me/e/3tDkNEgsf","iconEnabled":true,"serviceName":"facebook-unauth"}],"typekitId":"","statsMigrated":true,"imageMetadataProcessingEnabled":false,"screenshotId":"5053e56e","captchaSettings":{"enabledForDonations":false},"showOwnerLogin":false},"websiteSettings":{"id":"508a094ee4b0f50834e1e3d7","websiteId":"508a094ee4b0f50834e1e3d6","type":"Non-Profit","subjects":[{"systemSubject":"other","otherSubject":"Design/Art"}],"country":"NZ","state":"","simpleLikingEnabled":true,"mobileInfoBarSettings":{"isContactEmailEnabled":false,"isContactPhoneNumberEnabled":false,"isLocationEnabled":false,"isBusinessHoursEnabled":false},"commentLikesAllowed":true,"commentAnonAllowed":true,"commentThreaded":true,"commentApprovalRequired":false,"commentAvatarsOn":true,"commentSortType":2,"commentFlagThreshold":0,"commentFlagsAllowed":true,"commentEnableByDefault":true,"commentDisableAfterDaysDefault":0,"disqusShortname":"","commentsEnabled":true,"storeSettings":{"returnPolicy":null,"termsOfService":null,"privacyPolicy":null,"expressCheckout":true,"continueShoppingLinkUrl":"/","useLightCart":false,"showNoteField":false,"shippingCountryDefaultValue":"NZ","billToShippingDefaultValue":false,"showShippingPhoneNumber":true,"isShippingPhoneRequired":false,"showBillingPhoneNumber":true,"isBillingPhoneRequired":false,"currenciesSupported":["USD","ARS","AUD","BRL","CAD","CHF","COP","CZK","DKK","EUR","GBP","HKD","IDR","ILS","INR","JPY","MXN","MYR","NOK","NZD","PHP","PLN","RUB","SEK","SGD","THB","ZAR"],"defaultCurrency":"NZD","selectedCurrency":"NZD","measurementStandard":1,"showCustomCheckoutForm":false,"checkoutPageMarketingOptInEnabled":false,"enableMailingListOptInByDefault":false,"sameAsRetailLocation":false,"merchandisingSettings":{"scarcityEnabledOnProductItems":false,"scarcityEnabledOnProductBlocks":false,"scarcityMessageType":"DEFAULT_SCARCITY_MESSAGE","scarcityThreshold":10,"multipleQuantityAllowedForServices":true,"restockNotificationsEnabled":false,"restockNotificationsMailingListSignUpEnabled":false,"relatedProductsEnabled":false,"relatedProductsOrdering":"random","customSoldOutText":"Out Now","soldOutVariantsDropdownDisabled":true,"productComposerOptedIn":false,"productComposerABTestOptedOut":false,"productReviewsEnabled":false,"displayImportedProductReviewsEnabled":false,"hasOptedToCollectNativeReviews":false},"isLive":true,"multipleQuantityAllowedForServices":true},"useEscapeKeyToLogin":true,"ssBadgeType":1,"ssBadgePosition":4,"ssBadgeVisibility":1,"ssBadgeDevices":1,"pinterestOverlayOptions":{"mode":"disabled"},"ampEnabled":true},"cookieSettings":{"isCookieBannerEnabled":false,"isRestrictiveCookiePolicyEnabled":false,"isRestrictiveCookiePolicyAbsolute":false,"cookieBannerText":"","cookieBannerTheme":"","cookieBannerVariant":"","cookieBannerPosition":"","cookieBannerCtaVariant":"","cookieBannerCtaText":"","cookieBannerAcceptType":"OPT_IN","cookieBannerOptOutCtaText":""},"websiteCloneable":false,"collection":{"title":"Home","id":"508a094ee4b0f50834e1e3eb","fullUrl":"/home","publicCommentCount":0,"type":10,"permissionType":1},"subscribed":false,"appDomain":"squarespace.com","templateTweakable":true,"tweakJSON":{"outerPadding":"55px","pagePadding":"47px","product-gallery-auto-crop":"false","product-image-auto-crop":"true","topPadding":"35px","tweak-v1-related-products-title-spacing":"50px"},"templateId":"50749216e4b0933ed3da0a8d","templateVersion":"7","pageFeatures":[1,2,4],"gmRenderKey":"QUl6YVN5Q0JUUk9xNkx1dkZfSUUxcjQ2LVQ0QWVUU1YtMGQ3bXk4","templateScriptsRootUrl":"https://static1.squarespace.com/static/ta/5074801ae4b0933ed3d9d554/683/scripts/","betaFeatureFlags":["viewer-role-contributor-invites","crm_retention_segment","send_local_pickup_ready_email","site_user_email_change","fluid_engine","campaigns_new_image_layout_picker","commerce_site_visitor_metrics","member_areas_spanish_interviews","campaigns_discount_section_in_blasts","campaigns_global_uc_ab","campaigns_import_discounts","crm_waitlist_enforce_recaptcha_v3_enterprise","commerce_order_status_access","commerce_etsy_product_import","commerce_clearpay","campaigns_discount_section_in_automations","commerce_restock_notifications","crm_enable_recaptcha_v3_enterprise","crm_default_newsletter_block_to_campaigns","customer_accounts_email_verification","order_status_page_checkout_landing_enabled","multilingual_transactional_emails","campaigns_show_featured_templates","crm_remove_subscriber","crm_enforce_recaptcha_v3_enterprise","background_art_onboarding","commerce_etsy_shipping_import","customer_account_creation_recaptcha","accounting_orders_sync","campaigns_content_editing_survey","is_feature_gate_refresh_enabled","fluid_engine_clean_up_grid_contextual_change","member_areas_schedule_interview","campaigns_thumbnail_layout","nested_categories_migration_enabled","visitor_react_forms","marketing_landing_page","member_areas_provisioning_service","scripts_defer","campaigns_asset_picker"],"videoAssetsFeatureFlags":["mux-data-video-collection","mux-data-course-collection"],"impersonatedSession":false,"tzData":{"zones":[[720,null,"+12",null]],"rules":{}},"showAnnouncementBar":false,"recaptchaEnterpriseContext":{"recaptchaEnterpriseSiteKey":"6LdDFQwjAAAAAPigEvvPgEVbb7QBm-TkVJdDTlAv"},"i18nContext":{"timeZoneData":{"id":"Pacific/Wake","name":"Wake Island Time"}}};</script><script>SquarespaceFonts.loadViaContext(); Squarespace.load(window);</script>
+<script type="application/ld+json">{"url":"https://www.urbandreambrokerage.org.nz","name":"Urban Dream Brokerage","description":"<p>Nau mai Haere mai.&nbsp;<span>Urban Dream Brokerage provides space for new ideas in Wellington Te Whanganui </span>\u0101&nbsp;T<span>ara. Working with property managers, individuals and community groups UDB brokers the temporary use of vacant space for innovative projects, assisting in urban revitalisation. It is run by organisation</span><a target=\"_blank\" href=\"http://www.lettingspace.org.nz/\">&nbsp;</a><a target=\"_blank\" href=\"http://www.lettingspace.org.nz/\">Letting Space</a><span>.</span></p>","image":"//images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/e7e423b2-7ffb-490d-8d9c-8a8b9c2f8c21/UDB-Banner-116.png","@context":"http://schema.org","@type":"WebSite"}</script><script type="application/ld+json">{"legalName":"Urban Dream Brokerage","address":"Ground floor, 19 Tory Street\nWellington city\nNew Zealand","email":"urbandreambrokerage@gmail.com","sameAs":["https://fb.me/e/3tDkNEgsf"],"@context":"http://schema.org","@type":"Organization"}</script><script type="application/ld+json">{"address":"Ground floor, 19 Tory Street\nWellington city\nNew Zealand","image":"https://static1.squarespace.com/static/508a094ee4b0f50834e1e3d6/t/6396af1a4be5de371da80152/1685323414714/","name":"Urban Dream Brokerage","@context":"http://schema.org","@type":"LocalBusiness"}</script><link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/sitecss/508a094ee4b0f50834e1e3d6/95/50749216e4b0933ed3da0a8d/508a094fe4b0f50834e1e58b/683/site.css"/><script src="//uploader.squarewebsites.org/sqs-form-upload.min.js"></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
+<script>!function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';n.agent='plsquarespace';n.queue=[];t=b.createElement(e);t.async=!0;t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,document,'script','https://connect.facebook.net/en_US/fbevents.js');fbq('init', '377306786857519');fbq('track', "PageView");</script><!-- End of Squarespace Headers -->
+  <script src="https://static1.squarespace.com/static/ta/5074801ae4b0933ed3d9d554/683/scripts/core-0.2.0.min.js" type="text/javascript"></script>
+  <script type="text/javascript" src="https://static1.squarespace.com/static/ta/5074801ae4b0933ed3d9d554/683/scripts/combo/?dynamic-data.js&site.js"></script>
+  
+</head>
+
+<body class="page-borders-thin canvas-style-normal  header-subtitle-none banner-alignment-center blog-layout-right-sidebar project-layout-left-sidebar thumbnails-on-open-page-show-all social-icon-style-round  hide-info-footer hide-page-banner    hide-article-author    event-thumbnails event-thumbnail-size-32-standard event-date-label event-date-label-time event-list-show-cats event-list-date event-list-time event-list-address   event-icalgcal-links  event-excerpts  event-item-back-link    product-list-titles-under product-list-alignment-center product-item-size-11-square product-image-auto-crop product-gallery-size-11-square  show-product-price show-product-item-nav product-social-sharing tweak-v1-related-products-image-aspect-ratio-11-square tweak-v1-related-products-details-alignment-center newsletter-style-dark  opentable-style-light small-button-style-solid small-button-shape-square medium-button-style-solid medium-button-shape-square large-button-style-solid large-button-shape-square image-block-poster-text-alignment-center  image-block-card-content-position-center image-block-card-text-alignment-opposite image-block-overlap-dynamic-font-sizing image-block-overlap-content-position-center image-block-overlap-text-alignment-left image-block-collage-dynamic-font-sizing image-block-collage-content-position-top image-block-collage-text-alignment-left image-block-stack-dynamic-font-sizing image-block-stack-text-alignment-left button-style-outline button-corner-style-square tweak-product-quick-view-button-style-floating tweak-product-quick-view-button-position-bottom tweak-product-quick-view-lightbox-excerpt-display-truncate tweak-product-quick-view-lightbox-show-arrows tweak-product-quick-view-lightbox-show-close-button tweak-product-quick-view-lightbox-controls-weight-light native-currency-code-nzd collection-508a094ee4b0f50834e1e3eb collection-type-page collection-layout-default mobile-style-available logo-image" id="collection-508a094ee4b0f50834e1e3eb">
+
+  <div id="canvas">
+
+    <div id="mobileNav" class="">
+      <div class="wrapper">
+        <nav class="main-nav mobileNav"><ul>
+  
+
+        
+
+          
+
+            <li class="page-collection">
+
+              
+                <a href="/about">UDB</a>
+              
+
+              
+
+            </li>
+
+          
+
+            <li class="page-collection">
+
+              
+                <a href="/book">Brokered Dreams - The Book</a>
+              
+
+              
+
+            </li>
+
+          
+
+        
+
+      
+
+  
+
+        
+
+          <li class=" external-link">
+
+            
+
+            
+              <a href="/home">Activations</a>
+            
+
+          </li>
+
+        
+
+      
+
+  
+
+        
+
+          
+
+            <li class="page-collection">
+
+              
+                <a href="/process-2022">Process</a>
+              
+
+              
+
+            </li>
+
+          
+
+            <li class="page-collection">
+
+              
+                <a href="/criteria-2022">Criteria</a>
+              
+
+              
+
+            </li>
+
+          
+
+            <li class="page-collection">
+
+              
+                <a href="/apply">Apply</a>
+              
+
+              
+
+            </li>
+
+          
+
+        
+
+      
+
+  
+
+        
+
+          <li class="page-collection">
+
+            
+              <a href="/got-a-property">Property</a>
+            
+
+            
+
+          </li>
+
+        
+
+      
+
+  
+
+        
+
+          <li class="page-collection">
+
+            
+              <a href="/blog_1">Blog</a>
+            
+
+            
+
+          </li>
+
+        
+
+      
+
+  
+
+        
+
+          
+
+            <li class="page-collection">
+
+              
+                <a href="/contact">Contact</a>
+              
+
+              
+
+            </li>
+
+          
+
+            <li class="page-collection">
+
+              
+                <a href="/subscribe">Subscribe</a>
+              
+
+              
+
+            </li>
+
+          
+
+        
+
+      
+
+  
+</ul>
+</nav>
+      </div>
+    </div>
+    <div id="mobileMenuLink"><a>Menu</a></div>
+
+    <header id="header" data-content-field="site-title" class="clear">
+
+    
+
+      <div id="upper-logo">
+        <h1 class="logo"><a href="/"><img src="//images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/e7e423b2-7ffb-490d-8d9c-8a8b9c2f8c21/UDB-Banner-116.png?format=1500w" alt="Urban Dream Brokerage" /></a></h1>
+      </div>
+      <script type="module">
+        Y.use('squarespace-ui-base', function(Y) {
+          Y.one("#upper-logo .logo").plug(Y.Squarespace.TextShrink, {
+            parentEl: Y.one('#upper-logo')
+          });
+        });
+      </script>
+
+      
+      <div class="site-info">
+        <div class="site-address">Ground floor, 19 Tory Street</div>
+        <div class="site-city-state">Wellington city</div>
+        <div class="site-phone">Phone Number</div>
+      </div>
+      
+
+      <div class="site-tag-line">
+        <span>Space for new ideas in Wellington Te Whanganui ā Tara</span>
+      </div>
+
+      <div class="custom-info">
+        <div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Header Subtitle: Custom Content" data-type="block-field" data-updated-on="1350505672216" id="customInfoBlock"><div class="row sqs-row"><div class="col sqs-col-11 span-11"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-1b7f9ceb68a0d033e896"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <p class="text-align-left">Your Custom Text Goes Here</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-1 span-1"><div class="sqs-block search-block sqs-block-search" data-block-type="33" id="block-9c9009ce87cd31ce1514"><div class="sqs-block-content">
+
+<div class="sqs-search-ui-text-input sqs-search-ui-button-wrapper color-dark" data-source="block" data-preview="false" data-collection="">
+  <div class="spinner-wrapper"></div>
+  <input
+    type="search"
+    class="search-input"
+    value=""
+    placeholder="Search"
+    aria-label="Search"
+  />
+</div>
+</div></div></div></div></div>
+      </div>
+
+      <div id="lower-logo">
+        <h1 class="logo"><a href="/"><img src="//images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/e7e423b2-7ffb-490d-8d9c-8a8b9c2f8c21/UDB-Banner-116.png?format=1500w" alt="Urban Dream Brokerage" /></a></h1>
+      </div>
+      <script type="module">
+        Y.use('squarespace-ui-base', function(Y) {
+          Y.one("#lower-logo .logo").plug(Y.Squarespace.TextShrink, {
+            parentEl: Y.one('#lower-logo')
+          });
+        });
+      </script>
+
+    
+      <div id="topNav">
+  <nav class="main-nav" data-content-field="navigation">
+    <ul>
+    
+
+        <li class="folder-collection folder">
+
+          
+
+            <a aria-haspopup="true" >About</a>
+            <div class="subnav">
+              <ul>
+                
+                  
+                    <li class="page-collection">
+                      <a href="/about">UDB</a>
+                    </li>
+                  
+                  
+                
+                  
+                    <li class="page-collection">
+                      <a href="/book">Brokered Dreams - The Book</a>
+                    </li>
+                  
+                  
+                
+              </ul>
+            </div>
+
+          
+
+        </li>
+
+    
+
+        <li class=" external-link">
+
+          
+
+            
+
+            
+              <a href="/home">Activations</a>
+            
+
+
+          
+
+        </li>
+
+    
+
+        <li class="folder-collection folder">
+
+          
+
+            <a aria-haspopup="true" >Opportunities</a>
+            <div class="subnav">
+              <ul>
+                
+                  
+                    <li class="page-collection">
+                      <a href="/process-2022">Process</a>
+                    </li>
+                  
+                  
+                
+                  
+                    <li class="page-collection">
+                      <a href="/criteria-2022">Criteria</a>
+                    </li>
+                  
+                  
+                
+                  
+                    <li class="page-collection">
+                      <a href="/apply">Apply</a>
+                    </li>
+                  
+                  
+                
+              </ul>
+            </div>
+
+          
+
+        </li>
+
+    
+
+        <li class="page-collection">
+
+          
+
+            
+              <a href="/got-a-property">Property</a>
+            
+
+            
+
+
+          
+
+        </li>
+
+    
+
+        <li class="page-collection">
+
+          
+
+            
+              <a href="/blog_1">Blog</a>
+            
+
+            
+
+
+          
+
+        </li>
+
+    
+
+        <li class="folder-collection folder">
+
+          
+
+            <a aria-haspopup="true" >Contact</a>
+            <div class="subnav">
+              <ul>
+                
+                  
+                    <li class="page-collection">
+                      <a href="/contact">Contact</a>
+                    </li>
+                  
+                  
+                
+                  
+                    <li class="page-collection">
+                      <a href="/subscribe">Subscribe</a>
+                    </li>
+                  
+                  
+                
+              </ul>
+            </div>
+
+          
+
+        </li>
+
+    
+  </ul>
+  <div class="page-divider"></div>
+  </nav>
+</div>
+
+
+    </header>
+
+    <div class="page-divider top-divider"></div>
+
+    <!-- // page image or divider -->
+    
+      
+    
+
+    <section id="page" role="main" data-content-field="main-content">
+
+      <!-- // CATEGORY NAV -->
+      
+
+      <div class="sqs-layout sqs-grid-12 columns-12" data-type="page" data-updated-on="1684872045879" id="page-508a094ee4b0f50834e1e3eb"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1606297820523_97549"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h1 style="text-align:center;white-space:pre-wrap;">URBAN DREAM BROKERAGE ACTIVATIONS</h1><p class="" style="white-space:pre-wrap;"><br>Nau mai harere mai… welcome to Urban Dream Brokerage Te Whanganui-a-Tara. UDB has previously assisted and brokered space for over 120 creative projects from 2013. The programme has encouraged the innovative use of vacant retail and public space to creatively build community. In partnership with Wellington City Council we have received a strong mandate to continue our mahi of enlivening our cities streets, strengthening the mauri of our city. </p><blockquote><p class="" style="white-space:pre-wrap;">Urban Dream Brokerage is providing a supportive platform for artistic expressions in physical space by connecting private partners to community-minded arts-focused organisations, they also weave an important network in the collective arts. Cultivating this community bolsters and uplifts the practitioners involved, ultimately enriching Te Whanganui a Tara's environment through creative practice. - Jack Gittings - Mouthfull Collective</p></blockquote><p class="" style="white-space:pre-wrap;">For inspiration view images and information on all previous projects we've assisted in Wellington here, and we look forward to sharing more with you over the coming time. UDB has previously worked in Dunedin, Masterton and Porirua, <a href="/othercities">view those projects here.</a></p>
+</div>
+
+
+
+</div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1680129541345_125748"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1270px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/party-of-treasures"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.69290924072266%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/7b448ba6-96b0-4aaf-a07b-f3dc33b27d80/ErikaGrantHero_11_Resize.jpg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/7b448ba6-96b0-4aaf-a07b-f3dc33b27d80/ErikaGrantHero_11_Resize.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/7b448ba6-96b0-4aaf-a07b-f3dc33b27d80/ErikaGrantHero_11_Resize.jpg" data-image-dimensions="1270x847" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="646d1b5f146b66093cc2c668" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1680129541345_956498"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/party-of-treasures">Project #79 LGWD Commission #4 Party of Rare &amp; Unearthly Treasures</a></h3><p class="" style="white-space:pre-wrap;">The community is invited to collaborate in public sewing workshops crafting costumes comprised of found and recycled materials. These outfits, in the theme of ‘Surrealism’ will be worn by a live band and the public for the grand finale of the project <a href="/party-of-treasures">‘Party of Rare &amp; Unearthly Treasures’.</a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1680129541345_154224"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1200px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/udbtv"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.66667175292969%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/ecc22502-8dc7-49d5-8e4b-f23c8e17a608/UDBTV_Banner_1.jpg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/ecc22502-8dc7-49d5-8e4b-f23c8e17a608/UDBTV_Banner_1.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/ecc22502-8dc7-49d5-8e4b-f23c8e17a608/UDBTV_Banner_1.jpg" data-image-dimensions="1200x800" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="6440ad3ac415cb48b188cf23" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1680129541345_643726"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/udbtv">PROJECT #78 LGWD COMMISSION #3 UDBTV Refuse to upgrade </a>                              </h3><p class="" style="white-space:pre-wrap;">Proudly brought to you in standard definition, Mike Heynes and Kedron Parker use their community video production facility, activating the UDB provocation of “Let’s Get Wellington Dreaming”. Property Partner: Ash Holwell, Spacelamp. More information <a href="/udbtv">here.</a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1678313670108_437411"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1270px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/soft-serve-social"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.69290924072266%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/13ef2cb3-7f4a-4983-86c8-f2b230092a7c/HeroImage-Night_May.jpg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/13ef2cb3-7f4a-4983-86c8-f2b230092a7c/HeroImage-Night_May.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/13ef2cb3-7f4a-4983-86c8-f2b230092a7c/HeroImage-Night_May.jpg" data-image-dimensions="1270x847" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="64507cfe97a308683aa7108a" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1680129541345_327922"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/soft-serve-social">PROJECT #77 LGWD COMMISSION #2 PLAYeSCAPE URBAN SWING SET</a>  </h3><p class="" style="white-space:pre-wrap;">Soft Serve Social Collective explore ways we can feel present, calm and connected when we are alone in public space at any time of day. A gentle swing for the city. Partners: LT McGuinness, Studio Pacific &amp; WCC. More information <a href="/soft-serve-social">here.</a></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1674005714529_586155"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1270px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/callwaiting"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.69290924072266%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/662c3142-8182-41fd-9465-e1556c7dacd8/OandP_Resize_1.JPG" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/662c3142-8182-41fd-9465-e1556c7dacd8/OandP_Resize_1.JPG" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/662c3142-8182-41fd-9465-e1556c7dacd8/OandP_Resize_1.JPG" data-image-dimensions="1270x847" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="6440aa7ba26f1c6b2e839a31" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1674005714529_632433"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/callwaiting">PROJECT #76 LGWD COMMISSION #1 CALL/WAITING</a></h3><p class="" style="white-space:pre-wrap;">Presented by O and P Works, an app based pick your narrative journey through Courtenay Place exploring the tensions of working life. Property partner: Readings Cinema, 106 Courtenay Pl. More information <a href="/callwaiting">here.</a></p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="70.63492063492063" data-block-type="5" id="block-yui_3_17_2_1_1650852918361_339280"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:3360px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/urban-dreams"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:70.63491821289062%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/e70620a6-1c95-430c-b25a-3bd147326f1d/Ollie+Hutton_Screenshot.png" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/e70620a6-1c95-430c-b25a-3bd147326f1d/Ollie+Hutton_Screenshot.png" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/e70620a6-1c95-430c-b25a-3bd147326f1d/Ollie+Hutton_Screenshot.png" data-image-dimensions="3360x2100" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="63746247c4a7e17b4dc69753" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1650852918361_298716"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/urban-dreams">PROJECT #73 urban dreams - te wāhi o te papa whakāta </a></h3><p class="" style="white-space:pre-wrap;">A public art moving image commission. Eight independent moving artworks screening across eight weeks of winter. Property partner: Readings Cinema, 106 Courtenay Place. More information <a href="/urban-dreams">here.</a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1674005714529_573733"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1270px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/santas-ai"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.69290924072266%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/f836d884-c172-470f-9556-911029aab8b6/santa2_Resize.jpg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/f836d884-c172-470f-9556-911029aab8b6/santa2_Resize.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/f836d884-c172-470f-9556-911029aab8b6/santa2_Resize.jpg" data-image-dimensions="1270x847" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="63c872ad81b92b2af8f63e8a" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1674005714529_621156"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/santas-ai">PROJECT #75 Santas little Artifical Intelligence workShop </a> </h3><p class="" style="white-space:pre-wrap;">German artist Clara Ehrenwerth with Goethe Institute opened an AI Xmas print making shop. Inviting people to create Xmas prints while reflecting on AI in relation to artmaking. Property partner: Readings Cinema, 106 Courtenay Place.</p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="70.37037037037037" data-block-type="5" id="block-yui_3_17_2_1_1650852918361_333115"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1200px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/inhabit"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:70.37036895751953%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/ab15aba0-a580-4553-bdf1-fd9c92626251/Inhabit.jpg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/ab15aba0-a580-4553-bdf1-fd9c92626251/Inhabit.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/ab15aba0-a580-4553-bdf1-fd9c92626251/Inhabit.jpg" data-image-dimensions="1200x800" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="63438ae615a71e54bce931f0" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1650852918361_278005"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/inhabit">PROJECT #72 COMMISSIONED WORK #6 Inhabit post partum</a></h3><p class="" style="white-space:pre-wrap;">Artist Holli McEntegart creates a space where we examine how community, cultural and whānau postpartum care has changed in Aotearoa. Property partner: Readings Cinema, 106 Courtenay Place. More information <a href="/inhabit">here.</a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1674005714529_561288"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1270px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/a-work-about-the-housing-crisis-with-an-indoor-outdoor-flow"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.69290924072266%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/0c847f17-5b85-494b-980c-ece56461fe81/HRC_1.jpg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/0c847f17-5b85-494b-980c-ece56461fe81/HRC_1.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/0c847f17-5b85-494b-980c-ece56461fe81/HRC_1.jpg" data-image-dimensions="1270x847" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="63c872d28ec28c3534179c44" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1674005714529_609792"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/a-work-about-the-housing-crisis-with-an-indoor-outdoor-flow">PROJECT #74 COMMISSIONED WORK #6 A work about the housing crisis with an indoor outdoor flow</a></h3><p class="" style="white-space:pre-wrap;">Artist Heleyni Pratley filmed and projected conversations with people of the current housing crisis. Property partner: Readings Cinema, 106 Courtenay Place. More information <a href="/a-work-about-the-housing-crisis-with-an-indoor-outdoor-flow">here.</a></p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="70.66895368782161" data-block-type="5" id="block-yui_3_17_2_1_1645386007263_91777"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1200px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/a-place-for-local-making"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:70.66895294189453%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/9af2bc06-493d-43cd-a947-cd61bdec0623/A_X_3.jpg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/9af2bc06-493d-43cd-a947-cd61bdec0623/A_X_3.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/9af2bc06-493d-43cd-a947-cd61bdec0623/A_X_3.jpg" data-image-dimensions="1200x800" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="626a1fad8ec65809d41caaa9" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1645386168339_92742"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/a-place-for-local-making">PROJECT #71 COMMISSIONED WORK #5 A PLACE FOR LOCAL MAKING</a></h3><p class="" style="white-space:pre-wrap;">Artists Xin Cheng and Adam Ben-Dror hosted a series of workshops, talks and reading groups through to May 2022. Property partner: Readings Cinema, 106 Courtenay Place. More information <a href="/a-place-for-local-making">here.</a></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="70.82228116710876" data-block-type="5" id="block-yui_3_17_2_1_1636752768836_188819"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/slp-taniwha"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:70.82228088378906%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/7fc4785c-75f0-42f1-8f4e-119ac477a6d8/SLP_3.JPG" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/7fc4785c-75f0-42f1-8f4e-119ac477a6d8/SLP_3.JPG" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/7fc4785c-75f0-42f1-8f4e-119ac477a6d8/SLP_3.JPG" data-image-dimensions="1500x1000" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="61d77f636cd3c1547f745774" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1636752768836_203807"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/slp-taniwha">PROJECT #70 Shared Lines: Pūtahitanga and Awakening The Taniwha</a></h3><p class="" style="white-space:pre-wrap;">Shared Lines Collective invite the public to new ways we are working together in light of the impact of Covid. Property Partner: Wellington City Council. More information <a href="/slp-taniwha">here.</a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="70.84048027444254" data-block-type="5" id="block-yui_3_17_2_1_1634179550281_105774"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:800px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/the-original-homeless"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:70.8404769897461%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/470f8276-295a-47d8-ad21-fd6caa7bc56f/TOH_1.jpg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/470f8276-295a-47d8-ad21-fd6caa7bc56f/TOH_1.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/470f8276-295a-47d8-ad21-fd6caa7bc56f/TOH_1.jpg" data-image-dimensions="800x1200" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="637462025b828c6ff9ffafba" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1606196502442_156264"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/the-original-homeless">project #69: commission #4: The Original homeless</a></h3><p class="" style="white-space:pre-wrap;">Bek Coogan pushed her response to the neo-liberal housing crisis in Aotearoa.   Property Partner: WCC 115 Manners Street. More information <a href="/the-original-homeless">here.</a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="70.15437392795883" data-block-type="5" id="block-yui_3_17_2_1_1624944551879_979597"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1200px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/rongoa"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:70.15437316894531%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/b53d8bdc-9962-4282-bae6-ddf678dc5383/H%C4%81kari_1.jpg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/b53d8bdc-9962-4282-bae6-ddf678dc5383/H%C4%81kari_1.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/b53d8bdc-9962-4282-bae6-ddf678dc5383/H%C4%81kari_1.jpg" data-image-dimensions="1200x800" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="61bafe9fab5931758e3cc34f" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1624944551879_1249706"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/rongoa" target="">Project #68: Commission #3 Rongoā-Marae-ROA-a rangi: He Moemoeā</a></h3><p class="" style="white-space:pre-wrap;">Tanya Ruka uses Rongoā Māori to acknowledge the wairua of inner city Te Whanganui-a-Tara. Property Partner: Readings Cinema. 106 Manners Street. More information <a href="/rongo">h</a><a href="/rongoa" target="">e</a><a href="/rongo">re.</a></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="71.08753315649867" data-block-type="5" id="block-yui_3_17_2_1_1632890269923_421934"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2499px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/face-your-waste"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:71.08753204345703%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1632894030228-TPHUFQEVYE27A3V7H4D8/P1000390.JPG" alt="P1000390.JPG" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1632894030228-TPHUFQEVYE27A3V7H4D8/P1000390.JPG" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1632894030228-TPHUFQEVYE27A3V7H4D8/P1000390.JPG" data-image-dimensions="2499x1875" data-image-focal-point="0.5,0.5" alt="P1000390.JPG" data-load="false" data-image-id="6153ef1cba23857662bb34f0" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1634184347436_689946"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/face-your-waste" target="">Project #66: face your waste</a></h3><p class="" style="white-space:pre-wrap;">International Food Waste Day project run by volunteers from NZ Food Waste Champions Group of Citizens. Property Partner: WCC Container - Corner of Willis St &amp; Bond St. More information <a href="/face-your-waste" target="">here.</a></p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1612495775619_218025"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1618px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="http://urbandreambrokerage.org.nz/city-theatre"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:75.0309066772461%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1614721795521-Q5R3OVKJNBFO8WEN4Q0X/CAT-Prophetic%2BVisions_7-image_Markuza%2BMaric.jpg" alt="CAT-Prophetic+Visions_7-image_Markuza+Maric.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1614721795521-Q5R3OVKJNBFO8WEN4Q0X/CAT-Prophetic%2BVisions_7-image_Markuza%2BMaric.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1614721795521-Q5R3OVKJNBFO8WEN4Q0X/CAT-Prophetic%2BVisions_7-image_Markuza%2BMaric.jpg" data-image-dimensions="1618x1214" data-image-focal-point="0.5,0.5" alt="CAT-Prophetic+Visions_7-image_Markuza+Maric.jpg" data-load="false" data-image-id="603eb30057922029ec8d8521" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1612495775619_202163"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="http://urbandreambrokerage.org.nz/city-theatre">WHAT IF THE CITY WAS A THEATRE?</a></h3><p class="" style="white-space:pre-wrap;">‘<a href="https://www.citytheatre.co.nz/">What If The City Was a Theatre?</a>' is a free, Wellington-wide programme that reimagines the limits of public space. More information <a href="/city-theatre" target="">here. </a>                     </p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="73.74631268436578" data-block-type="5" id="block-yui_3_17_2_1_1529888081702_88145"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:640px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/mouthfull-manifesto"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:73.7463150024414%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1532566479480-NOIWLQRK7WGJ9MTK8KF0/IMG_2846.JPG" alt="IMG_2846.JPG" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1532566479480-NOIWLQRK7WGJ9MTK8KF0/IMG_2846.JPG" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1532566479480-NOIWLQRK7WGJ9MTK8KF0/IMG_2846.JPG" data-image-dimensions="640x480" data-image-focal-point="0.5,0.5" alt="IMG_2846.JPG" data-load="false" data-image-id="5b591bce0e2e72dd68dedc8d" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1529888081702_158655"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/mouthfull-manifesto"><strong>PROJECT #61: MANIFESTO</strong></a></h3><p class="" style="white-space:pre-wrap;">Mouthfull Productions. Clyde Quay Wharf. June 2018 - ongoing. More information <a href="/mouthfull-manifesto">here</a>.</p>
+</div>
+
+
+
+</div></div><div class="sqs-block horizontalrule-block sqs-block-horizontalrule" data-block-type="47" id="block-yui_3_17_2_1_1613527758362_104565"><div class="sqs-block-content"><hr /></div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="70.37037037037037" data-block-type="5" id="block-yui_3_17_2_1_1624944551879_774268"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:3888px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/commonspace"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:70.37036895751953%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/bea07391-8789-4a7d-8959-e76461df4cd4/CS_Blog_1+websize.jpg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/bea07391-8789-4a7d-8959-e76461df4cd4/CS_Blog_1+websize.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/bea07391-8789-4a7d-8959-e76461df4cd4/CS_Blog_1+websize.jpg" data-image-dimensions="3888x2592" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="618ece4328151700f73923e9" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1624944551879_1233976"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/commonspace">Project #67: Commission #2 commonspace</a></h3><p class="" style="white-space:pre-wrap;">Mouthfull create a central place of being and belonging, learning and connecting. Property Partner: Ash Holwell. 113 Taranaki St. 21 July - 31 October 2021. More information <a href="/commonspace">here.</a></p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1614723844643_115985"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1626px;"
+        >
+          
+        
+        
+
+        
+          
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:75.03074645996094%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1614724108361-FZWIM610R3V73YA411X8/CAT%252B-%252BEchoes_1-image%25252BMarkuza%252BMaric.jpg" alt="CAT%2B-%2BEchoes_1-image%252BMarkuza%2BMaric.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1614724108361-FZWIM610R3V73YA411X8/CAT%252B-%252BEchoes_1-image%25252BMarkuza%252BMaric.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1614724108361-FZWIM610R3V73YA411X8/CAT%252B-%252BEchoes_1-image%25252BMarkuza%252BMaric.jpg" data-image-dimensions="1626x1220" data-image-focal-point="0.5,0.5" alt="CAT%2B-%2BEchoes_1-image%252BMarkuza%2BMaric.jpg" data-load="false" data-image-id="603ebc0aeef1f330f083c4a6" data-type="image" />
+                
+            </div>
+          </div>
+        
+          
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1613515707036_109759"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="http://urbandreambrokerage.org.nz/echoes-2021">Project #64: echoes</a></h3><p class="" style="white-space:pre-wrap;">Joe Dixon and Storybox. Property Partner: Willis Bond. 106a Cuba Street, Te Aro, Wellington. 5 - 28 February 2021. More information <a href="http://urbandreambrokerage.org.nz/echoes-2021">here.</a></p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1610514884074_317431"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1829px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="http://urbandreambrokerage.org.nz/101rants"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:74.95899200439453%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1611630868899-401QIBUVTVGCQYDP51QM/101%2BRants%2BHERO%2BImage.jpg" alt="101+Rants+HERO+Image.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1611630868899-401QIBUVTVGCQYDP51QM/101%2BRants%2BHERO%2BImage.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1611630868899-401QIBUVTVGCQYDP51QM/101%2BRants%2BHERO%2BImage.jpg" data-image-dimensions="1829x1371" data-image-focal-point="0.5,0.5" alt="101+Rants+HERO+Image.jpg" data-load="false" data-image-id="600f89134096c703223a5c42" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1610514884074_328541"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/101rants">PROJECT #62: 101 RANTS</a></h3><p class="" style="white-space:pre-wrap;">Marcus McShane. Property Partner: Michael Wall. 253 Wakefield Street. 13 - 28 January 2020. More information <a href="http://urbandreambrokerage.org.nz/101rants">here</a>.</p>
+</div>
+
+
+
+</div></div><div class="sqs-block horizontalrule-block sqs-block-horizontalrule" data-block-type="47" id="block-yui_3_17_2_1_1613527758362_110079"><div class="sqs-block-content"><hr /></div></div><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1526348632048_101403"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2423px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/crafted-voice"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:74.98968505859375%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1526350841949-NY75U8YTJZPVSNKX1ECO/Gentle+voice+6.jpg" alt="Gentle voice 6.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1526350841949-NY75U8YTJZPVSNKX1ECO/Gentle+voice+6.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1526350841949-NY75U8YTJZPVSNKX1ECO/Gentle+voice+6.jpg" data-image-dimensions="2423x1817" data-image-focal-point="0.5,0.5" alt="Gentle voice 6.jpg" data-load="false" data-image-id="5afa43eb575d1ff8cd9b10b7" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1526351500701_227945"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/crafted-voice"><strong>PROJECT #60: the CRAFTED VOICE</strong></a></h3><p class="" style="white-space:pre-wrap;">Rosie White. Wellington public library, hospital and district court. 19-21 June 21018. More information <a href="/crafted-voice">here</a>.</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="70.37037037037037" data-block-type="5" id="block-yui_3_17_2_1_1618181742214_294679"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1860px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="http://urbandreambrokerage.org.nz/electromagnetic-geographies"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:70.37036895751953%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1622948464299-181FGQHBI03INDHUTA50/EMG_Artists_1.jpg" alt="EMG_Artists_1.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1622948464299-181FGQHBI03INDHUTA50/EMG_Artists_1.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1622948464299-181FGQHBI03INDHUTA50/EMG_Artists_1.jpg" data-image-dimensions="1860x1240" data-image-focal-point="0.5,0.5" alt="EMG_Artists_1.jpg" data-load="false" data-image-id="60bc3a627e99d538c4c3a455" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1632890269923_610630"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/electromagnetic-geographies">Project #65 COMMISSION #1 ELECTROMAGNETIC GEOGRAPHIES</a></h3><p class="" style="white-space:pre-wrap;">Artist and critical engineer Julian Oliver and participating artists. Property Partner: Willis Bond. 106a Cuba St. 10-30 May 2021. More information <a href="http://urbandreambrokerage.org.nz/electromagnetic-geographies">here.</a></p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="73.01587301587301" data-block-type="5" id="block-yui_3_17_2_1_1612495775619_246180"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2189px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="http://urbandreambrokerage.org.nz/the-builders-fringe"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:73.01587677001953%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1622948668103-RDR3QUFBP11TN81TT5OY/TBF_1.jpg" alt="TBF_1.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1622948668103-RDR3QUFBP11TN81TT5OY/TBF_1.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1622948668103-RDR3QUFBP11TN81TT5OY/TBF_1.jpg" data-image-dimensions="2189x2240" data-image-focal-point="0.5,0.5" alt="TBF_1.jpg" data-load="false" data-image-id="60bc3b3027cb4f57a31f6fd3" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1612495775619_235633"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="http://urbandreambrokerage.org.nz/the-builders-fringe">PROJECT #63: THE BUILDERS’ FRINGE</a></h3><p class="" style="white-space:pre-wrap;">Maverick Creative. Property Partner: Willis Bond &amp; LT McGuinness. 161 Victoria St. 8-12 March 2021. More information <a href="http://urbandreambrokerage.org.nz/the-builders-fringe">here</a>.</p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1611630814198_280263"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2222px;"
+        >
+          
+        
+        
+
+        
+          
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:75.02249908447266%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1611638387528-8P8KNADZQ0TSOQO0G7I5/1%2BHERO%2BUBD%2B2.0%2B-%2BWEB%2B-%2BLAUNCH%2B17.12.2020%2B-%2BEbony%2BLamb%2BPhotographer-31.jpg" alt="1+HERO+UBD+2.0+-+WEB+-+LAUNCH+17.12.2020+-+Ebony+Lamb+Photographer-31.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1611638387528-8P8KNADZQ0TSOQO0G7I5/1%2BHERO%2BUBD%2B2.0%2B-%2BWEB%2B-%2BLAUNCH%2B17.12.2020%2B-%2BEbony%2BLamb%2BPhotographer-31.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1611638387528-8P8KNADZQ0TSOQO0G7I5/1%2BHERO%2BUBD%2B2.0%2B-%2BWEB%2B-%2BLAUNCH%2B17.12.2020%2B-%2BEbony%2BLamb%2BPhotographer-31.jpg" data-image-dimensions="2222x1667" data-image-focal-point="0.5,0.5" alt="1+HERO+UBD+2.0+-+WEB+-+LAUNCH+17.12.2020+-+Ebony+Lamb+Photographer-31.jpg" data-load="false" data-image-id="600fa66e9411b043404eae15" data-type="image" />
+                
+            </div>
+          </div>
+        
+          
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1611630814198_245144"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="http://urbandreambrokerage.org.nz/relaunchparty">UDB RELAUNCH celebration </a></h3><p class="" style="white-space:pre-wrap;">A celebratory launch of&nbsp;<a href="http://urbandreambrokerage.org.nz/book">Brokered&nbsp;Dreams: 98 Uses For Vacant Space</a> and the relaunch of&nbsp;Urban&nbsp;Dream&nbsp;Brokerage.</p>
+</div>
+
+
+
+</div></div><div class="sqs-block horizontalrule-block sqs-block-horizontalrule" data-block-type="47" id="block-yui_3_17_2_1_1613527758362_115460"><div class="sqs-block-content"><hr /></div></div><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="74.7148288973384" data-block-type="5" id="block-yui_3_17_2_1_1526348632048_85613"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1600px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/fragments"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:74.71482849121094%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1529879681623-JZG6JON53KMV72WAA919/Candace+Telephone+kiosk28.jpg" alt="Candace Telephone kiosk28.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1529879681623-JZG6JON53KMV72WAA919/Candace+Telephone+kiosk28.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1529879681623-JZG6JON53KMV72WAA919/Candace+Telephone+kiosk28.jpg" data-image-dimensions="1600x1068" data-image-focal-point="0.5,0.5" alt="Candace Telephone kiosk28.jpg" data-load="false" data-image-id="5b301c7503ce6498ad5851f0" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1610514884074_302879"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/fragments"><strong>PROJECT #59: FRAGMENTS</strong></a></h3><p class="" style="white-space:pre-wrap;">Candace Smith. Various public locations. 10-25 June 2018. More information <a href="/fragments">here</a>.</p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="55.75221238938053" data-block-type="5" id="block-yui_3_17_2_1_1522712968260_82263"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:800px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/the-lost-futures-exchange"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:55.75221252441406%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1528789351689-88C3ORSQH7DP4R8W79YP/14-36-08_30-05-18.jpg" alt="14-36-08_30-05-18.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1528789351689-88C3ORSQH7DP4R8W79YP/14-36-08_30-05-18.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1528789351689-88C3ORSQH7DP4R8W79YP/14-36-08_30-05-18.jpg" data-image-dimensions="800x534" data-image-focal-point="0.5,0.5" alt="14-36-08_30-05-18.jpg" data-load="false" data-image-id="5b1f7967758d460b34db850a" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1522712968260_238870"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/the-lost-futures-exchange"><strong>Project #58: The Lost Futures Exchange</strong></a></h3><p class="" style="white-space:pre-wrap;">Mark Antony Smith. Property Partner:&nbsp;Bizdojo.&nbsp;3 Market Lane. 6 April - 30 May 2018, Thursdays 1pm-5pm. More information <a href="/the-lost-futures-exchange">here</a>.</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="56.932153392330385" data-block-type="5" id="block-yui_3_17_2_1_1522712968260_93895"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1024px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/new-page-2"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:56.932151794433594%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1530486980709-54X816EUCW14DDND60BS/imagejpeg_1.jpg" alt="imagejpeg_1.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1530486980709-54X816EUCW14DDND60BS/imagejpeg_1.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1530486980709-54X816EUCW14DDND60BS/imagejpeg_1.jpg" data-image-dimensions="1024x768" data-image-focal-point="0.5,0.5" alt="imagejpeg_1.jpg" data-load="false" data-image-id="5b3960c4562fa78787cb6480" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1522712968260_242868"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/new-page-2" target="_blank"><strong>2018 Peer to Peer Mentorship Programme</strong></a></h3><p class="" style="white-space:pre-wrap;">Rosie White with Jo Randerson, Mark Antony Smith with Leo-Gene Peters, Candace Smith with Vivien Atkinson, and Mouthfull with Sam Trubridge. More information <a href="/new-page-2">here</a>.</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="56.342182890855455" data-block-type="5" id="block-yui_3_17_2_1_1523330494548_84820"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1000px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/urban-dreams-podcast"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:56.34218215942383%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1523330618769-RCAIFD4M9J74MXJLCQO5/_AA97620.jpg" alt="_AA97620.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1523330618769-RCAIFD4M9J74MXJLCQO5/_AA97620.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1523330618769-RCAIFD4M9J74MXJLCQO5/_AA97620.jpg" data-image-dimensions="1000x667" data-image-focal-point="0.5,0.5" alt="_AA97620.jpg" data-load="false" data-image-id="5acc2e318a922dc77306358f" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1523330494548_220229"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/urban-dreams-podcast"><strong>&nbsp;2017-2018 urban dreams conversation AND PODCAST</strong></a></h3><p class="" style="white-space:pre-wrap;">More information <a href="/urban-dreams-podcast">here</a>.</p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="67.15976331360946" data-block-type="5" id="block-yui_3_17_2_3_1509495580161_67673"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/performance-art-week-aotearoa"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:67.15975952148438%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1510780067950-CK31ZNT8G98SF0GQNVVP/IMG_0868.jpg" alt="IMG_0868.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1510780067950-CK31ZNT8G98SF0GQNVVP/IMG_0868.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1510780067950-CK31ZNT8G98SF0GQNVVP/IMG_0868.jpg" data-image-dimensions="2500x1875" data-image-focal-point="0.5,0.5" alt="IMG_0868.jpg" data-load="false" data-image-id="5a0cac77652dea776ad8b340" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_3_1509495580161_101701"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/performance-art-week-aotearoa"><strong>PROJECT #57: PERFORMANCE ART WEEK AOTEAROA</strong> </a></h3><p class="" style="white-space:pre-wrap;">8-12 November 2017. 17 Tory Street and Play_Station. More information <a href="/performance-art-week-aotearoa">here</a>.</p><p class="" style="white-space:pre-wrap;">&nbsp;</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_5_1505177060938_78516"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/shared-lines"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.68000030517578%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1508985491221-UX3RUGGVDMTMLWZF2FC2/UBD+-+Shared+lines+Colour+-+low+res+-+Ebony+Lamb+10.17-3.jpg" alt="UBD - Shared lines Colour - low res - Ebony Lamb 10.17-3.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1508985491221-UX3RUGGVDMTMLWZF2FC2/UBD+-+Shared+lines+Colour+-+low+res+-+Ebony+Lamb+10.17-3.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1508985491221-UX3RUGGVDMTMLWZF2FC2/UBD+-+Shared+lines+Colour+-+low+res+-+Ebony+Lamb+10.17-3.jpg" data-image-dimensions="2500x1667" data-image-focal-point="0.5,0.5" alt="UBD - Shared lines Colour - low res - Ebony Lamb 10.17-3.jpg" data-load="false" data-image-id="59f14a8d90bcce5ece01afaf" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_3_1505178903510_135172"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/shared-lines"><strong>PROJECT #56: SHARED LINES: WELLINGTON</strong></a></h3><p class="" style="white-space:pre-wrap;">Property partner: Willis Bond. Waterfront, Adam Auditorium City Gallery, Thistle Hall Gallery 17-21 October 2017. More information <a href="/shared-lines">here</a>.<br>&nbsp;</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_9_1505177060938_223591"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:800px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/retail-cabaret"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.75%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1505879060692-1F3HTGZKKTDKY8UVTVWZ/19-47-29_18-09-17.jpg" alt="19-47-29_18-09-17.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1505879060692-1F3HTGZKKTDKY8UVTVWZ/19-47-29_18-09-17.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1505879060692-1F3HTGZKKTDKY8UVTVWZ/19-47-29_18-09-17.jpg" data-image-dimensions="800x534" data-image-focal-point="0.5,0.5" alt="19-47-29_18-09-17.jpg" data-load="false" data-image-id="59c1e41329f1870809c01a14" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_3_1505178903510_84102"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/retail-cabaret"><strong>PROJECT #55: RETAIL CABARET</strong></a></h3><p class="" style="white-space:pre-wrap;">Property partner: Scruffy Bunny. Readings Cinemas Courtenay Central. 19 – 22 September 2017 8pm, 23 September 3pm. More information <a href="/retail-cabaret">here</a>.</p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_3_1504051298492_77275"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/political-cutz-2017"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.68000030517578%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1504598796659-ZKOZ6LK7KBUKVQJJBPMM/UDB+-+POL+CUTZ++web+res+-+E.Lamb+2017-115.jpg" alt="UDB - POL CUTZ  web res - E.Lamb 2017-115.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1504598796659-ZKOZ6LK7KBUKVQJJBPMM/UDB+-+POL+CUTZ++web+res+-+E.Lamb+2017-115.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1504598796659-ZKOZ6LK7KBUKVQJJBPMM/UDB+-+POL+CUTZ++web+res+-+E.Lamb+2017-115.jpg" data-image-dimensions="2500x1667" data-image-focal-point="0.5,0.5" alt="UDB - POL CUTZ  web res - E.Lamb 2017-115.jpg" data-load="false" data-image-id="59ae5b06b8a79b5194ccf121" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_9_1504051298492_91270"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/political-cutz-2017"><strong>PROJECT #54: POLITICAL CUTZ 2017</strong></a></h3><p class="" style="white-space:pre-wrap;">Barbarian Productions/Maverick Creative. Property: Maurice and Kaye Clarke. Public Trust Building, 131 Lambton Quay. 5-9 September 2017, 10am-4pm (Thurs until 6pm). More information <a href="/political-cutz-2017">here</a>.</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="66.41221374045801" data-block-type="5" id="block-yui_3_17_2_3_1498795888546_78222"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/project-fashion"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.41221618652344%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1501213185141-TU457MWRP9751XBRS1H8/UDB+Public+Trust+colour-+July+17+-+E.Lamb+Photography-26.jpg" alt="UDB Public Trust colour- July 17 - E.Lamb Photography-26.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1501213185141-TU457MWRP9751XBRS1H8/UDB+Public+Trust+colour-+July+17+-+E.Lamb+Photography-26.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1501213185141-TU457MWRP9751XBRS1H8/UDB+Public+Trust+colour-+July+17+-+E.Lamb+Photography-26.jpg" data-image-dimensions="2500x1667" data-image-focal-point="0.5,0.5" alt="UDB Public Trust colour- July 17 - E.Lamb Photography-26.jpg" data-load="false" data-image-id="597ab1fc3e00be4519178810" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_3_1498795888546_95162"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/project-fashion"><strong>PROJECT #53: PROJECT FASHION</strong></a></h3><p class="" style="white-space:pre-wrap;">The Display Space. Property: Maurice and Kaye Clarke. Public Trust Building, 131 Lambton Quay. 13-31 July 2017. Tues-Sat 10am-6pm. More information <a href="/project-fashion">here</a>.</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_6_1493944269061_74533"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2000px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/unsettled"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.75%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1496719132033-6J28NRPHYAVEAGKZWT1P/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1496719132033-6J28NRPHYAVEAGKZWT1P/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1496719132033-6J28NRPHYAVEAGKZWT1P/image-asset.jpeg" data-image-dimensions="2000x1335" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="59361f149de4bbb02330621a" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_3_1498795888546_238459"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/unsettled"><strong>PROJECT #52: unsettled</strong></a></h3><p class="" style="white-space:pre-wrap;">Rana Haddad and Pascal Hachem. Property partner: Zebrano. 2 Tory Street. May 3 – 16 2017. More information <a href="/unsettled">here.</a></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_3_1492990944624_76752"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:525px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/the-song-dispensary"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.66667175292969%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1492991009257-9D3I173R35CVTDQG8APG/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1492991009257-9D3I173R35CVTDQG8APG/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1492991009257-9D3I173R35CVTDQG8APG/image-asset.jpeg" data-image-dimensions="525x350" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="58fd3c20ff7c502a493da6d7" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_3_1492990944624_153472"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/the-song-dispensary"><strong>Project #51: The Song Dispensary</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Hans Kellett and Dan Untitled. Property partner: Zebrano. 2 Tory Street. April 26 – 30, 2017. More information </strong><a href="/the-song-dispensary"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="66.6030534351145" data-block-type="5" id="block-yui_3_17_2_3_1487724286954_68190"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/fouvale-imperium"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.6030502319336%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1488429211691-J3YV6V7SXFUZHQWZ6HPC/UDB+-+E.Lamb+23.02.17+Low+res+-+Colour+-16.jpg" alt="UDB - E.Lamb 23.02.17 Low res - Colour -16.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1488429211691-J3YV6V7SXFUZHQWZ6HPC/UDB+-+E.Lamb+23.02.17+Low+res+-+Colour+-16.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1488429211691-J3YV6V7SXFUZHQWZ6HPC/UDB+-+E.Lamb+23.02.17+Low+res+-+Colour+-16.jpg" data-image-dimensions="2500x1667" data-image-focal-point="0.5,0.5" alt="UDB - E.Lamb 23.02.17 Low res - Colour -16.jpg" data-load="false" data-image-id="58b7a095bf629a0675924935" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_6_1487721825235_70644"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/fouvale-imperium"><strong>PROJECT #50: FOUVALE IMPERIUM</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>James Nokise. Clyde Quay Wharf. Property partner: Wellington City Council. 21 - 25 February 2017. More information </strong><a href="/fouvale-imperium"><strong>here</strong></a><strong>.</strong></p><p class="" style="white-space:pre-wrap;">&nbsp;</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="66.22137404580153" data-block-type="5" id="block-yui_3_17_2_6_1485817758538_64552"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/tapes"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.22137451171875%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1489111036982-T8ILO72MC496B32VJMGK/IMG_7349.jpg" alt="IMG_7349.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1489111036982-T8ILO72MC496B32VJMGK/IMG_7349.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1489111036982-T8ILO72MC496B32VJMGK/IMG_7349.jpg" data-image-dimensions="2500x1667" data-image-focal-point="0.5,0.5" alt="IMG_7349.jpg" data-load="false" data-image-id="58c207f46a4963a1d42df1ed" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_6_1485817758538_155741"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/tapes"><strong>PROJECT #49 THE BASEMENT TAPES</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Stella Reid. Property partner: Wellington City Council. 10 -13 February 2017. Clyde Quay Wharf. More information </strong><a href="/tapes"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_3_1478554626360_63589"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2000px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/galathea-into-the-bush"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.75%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1480015962644-T1KKAEBQXF09WOBGZ2E7/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1480015962644-T1KKAEBQXF09WOBGZ2E7/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1480015962644-T1KKAEBQXF09WOBGZ2E7/image-asset.jpeg" data-image-dimensions="2000x1335" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="58374059414fb5a61506875c" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_3_1478554626360_75747"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/galathea-into-the-bush"><strong>PROJECT #48: GALATHEA INTO THE BUSH</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Twin City Productions. Property partners: Maurice and Kaye Clark. Public Trust Building, 131 Lambton Quay. 23 November - 3 December 2016. More information </strong><a href="/galathea-into-the-bush"><strong>here</strong></a><strong>.</strong></p><p class="" style="white-space:pre-wrap;">&nbsp;</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_7_1474408287193_66896"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2000px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/glade"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.75%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1477011634560-S7Z7MMK9HQFFUFE6R4PR/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1477011634560-S7Z7MMK9HQFFUFE6R4PR/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1477011634560-S7Z7MMK9HQFFUFE6R4PR/image-asset.jpeg" data-image-dimensions="2000x1335" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="580968b0d482e9896765ce07" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_7_1474408287193_74840"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/glade"><strong>PROJECT #47: GLADE</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Lux. Property partner: Wellington City Council. 6/22 Herd Street (meeting place). 30 September - 9 October. 12pm-8pm. More information </strong><a href="/glade"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_8_1475018225469_79388"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/cyber-nectar"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.68000030517578%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1475019169432-SXK3U3GZT6K5K0SQJAE4/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1475019169432-SXK3U3GZT6K5K0SQJAE4/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1475019169432-SXK3U3GZT6K5K0SQJAE4/image-asset.jpeg" data-image-dimensions="2500x1667" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="57eb019446c3c474982f99b3" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_8_1475018225469_108483"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/cyber-nectar"><strong>PROJECT #46: CYBER NECTAR</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Lokal Stories. Properties: various. 28 September - 14 October. More information </strong><a href="/cyber-nectar"><strong>here</strong></a><strong>.</strong></p><p class="" style="white-space:pre-wrap;">&nbsp;</p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="56.91823899371069" data-block-type="5" id="block-yui_3_17_2_6_1469052940196_70578"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:495px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/coliberate"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:56.91823959350586%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1469053482056-CQY5LIL0EURW4ECVYDP8/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1469053482056-CQY5LIL0EURW4ECVYDP8/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1469053482056-CQY5LIL0EURW4ECVYDP8/image-asset.jpeg" data-image-dimensions="495x384" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="578ff9694402434ae8dad9ae" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_3_1470197610120_414169"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/coliberate"><strong>PROJECT #45: CO-LIBERATE</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Property Partner: Mt Iron Investments Ltd. Level 2, 111 Customhouse Quay. 31st July, 2016 - ongoing. More information </strong><a href="/coliberate"><strong>here</strong></a><strong>.</strong></p><p class="" style="white-space:pre-wrap;">&nbsp;</p><p class="" style="white-space:pre-wrap;">&nbsp;</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="56.91823899371069" data-block-type="5" id="block-yui_3_17_2_7_1468898886075_72126"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:3456px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/unseasonal-change"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:56.91823959350586%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1470276005759-V8CVYDPRC3EBJKRERPU8/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1470276005759-V8CVYDPRC3EBJKRERPU8/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1470276005759-V8CVYDPRC3EBJKRERPU8/image-asset.jpeg" data-image-dimensions="3456x2304" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="57a2a19946c3c4ef06cce4cc" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_3_1470197610120_344591"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/unseasonal-change"><strong>PROJECT #44: UNSEASONAL CHANGE</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Andrea Selwood. Property Partner: Wellington City Council. 1 Clyde Quay Wharf.&nbsp;July 20th -August 20th&nbsp;2016. More information </strong><a href="/unseasonal-change"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_3_1465946672170_60614"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:650px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/bike-laboratory-2016"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:56.153846740722656%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1466468675139-X9YEER30STBS053DSK2O/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1466468675139-X9YEER30STBS053DSK2O/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1466468675139-X9YEER30STBS053DSK2O/image-asset.jpeg" data-image-dimensions="650x365" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="5768891646c3c4f6756fb83c" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_7_1465947015038_63910"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/bike-laboratory-2016"><strong>PROJECT #43:&nbsp;Lucid Dreambike laboratory</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Property Partner: Wellington City Council. 1 Clyde Quay Wharf.&nbsp;17th June - 17th July 2016. More information </strong><a href="/bike-laboratory-2016"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="56.582633053221286" data-block-type="5" id="block-yui_3_17_2_3_1457401952118_59351"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2246px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/lightning-lab-xx"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:56.58263397216797%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1457402054666-TM65HO4Z5FGU10O6WNE8/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1457402054666-TM65HO4Z5FGU10O6WNE8/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1457402054666-TM65HO4Z5FGU10O6WNE8/image-asset.jpeg" data-image-dimensions="2246x1070" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="56de30c0d51cd41a9a3550af" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_12_1456181556899_150189"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/lightning-lab-xx"><strong>PROJECT #42:&nbsp;LIGHTNING LAB XX</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Level 1, 7 Dixon St.&nbsp;From 1st March 2016. More information </strong><a href="/lightning-lab-xx"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="56.582633053221286" data-block-type="5" id="block-yui_3_17_2_12_1456181556899_157903"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:640px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/idlenesslabouritory"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:56.58263397216797%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1459912377514-4LJPOVEDYT9H7HQ8NTHJ/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1459912377514-4LJPOVEDYT9H7HQ8NTHJ/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1459912377514-4LJPOVEDYT9H7HQ8NTHJ/image-asset.jpeg" data-image-dimensions="640x480" data-image-focal-point="0.5,0.5923076923076923" alt="" data-load="false" data-image-id="57047eb7e321408a6313a25e" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_2_1448923585618_67043"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/idlenesslabouritory"><strong>PROJECT #41: IDLENESS LABORATORY</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Property Partner: Cook Strait Properties. 1 Marjoribanks Street. 8-9 March 2016.&nbsp;More info </strong><a href="/idlenesslabouritory"><strong>here.</strong></a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="56.5359477124183" data-block-type="5" id="block-yui_3_17_2_3_1455762008844_55757"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1000px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/scratch-nacht"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:56.535945892333984%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1455762823299-99KA7MVZBMRMLQ36Z0CQ/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1455762823299-99KA7MVZBMRMLQ36Z0CQ/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1455762823299-99KA7MVZBMRMLQ36Z0CQ/image-asset.jpeg" data-image-dimensions="1000x1000" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="56c52d6a2e83f8adcf3a3a4e" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_3_1455762008844_516548"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/scratch-nacht"><strong>PROJECT #40: SCRATCH NACHT</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Property Partner: Wellington City Council. 1 Clyde Quay Wharf. 22-29 February 2016. More information </strong><a href="/scratch-nacht"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="61.834319526627226" data-block-type="5" id="block-yui_3_17_2_3_1455762008844_597797"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2000px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/groeni-x-joel-fear"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:61.834320068359375%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1456182120241-EQTS5N4WFTBZWYZSNX3O/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1456182120241-EQTS5N4WFTBZWYZSNX3O/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1456182120241-EQTS5N4WFTBZWYZSNX3O/image-asset.jpeg" data-image-dimensions="2000x1335" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="56cb935ae707ebc39cedb756" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_6_1465255983598_395155"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/groeni-x-joel-fear"><strong>PROJECT #39: GROENI X JOEL FEAR</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Property Partner: Horsfall Properties. 88 Riddiford Street. From 17 February 2016. More information </strong><a href="/groeni-x-joel-fear"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="61.53846153846154" data-block-type="5" id="block-yui_3_17_2_2_1448921922403_349716"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2048px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/hawaii-cultural-centre"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:61.53845977783203%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1449538353024-WWOA5ZR5J0KV93DPWCL0/IMG_0089.JPG" alt="IMG_0089.JPG" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1449538353024-WWOA5ZR5J0KV93DPWCL0/IMG_0089.JPG" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1449538353024-WWOA5ZR5J0KV93DPWCL0/IMG_0089.JPG" data-image-dimensions="2048x1365" data-image-focal-point="0.5,0.5" alt="IMG_0089.JPG" data-load="false" data-image-id="5666332ca976afddc7096ef3" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_6_1465255983598_411027"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/hawaii-cultural-centre"><strong>PROJECT #38: HAWAI'I CULTURE CENTRE</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Property Partner: Prime Property. 20 Ballance Street. From 1st December 2015. More information </strong><a href="/hawaii-cultural-centre"><strong>here</strong></a><strong>.&nbsp;</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="61.0079575596817" data-block-type="5" id="block-yui_3_17_2_2_1448920263980_69139"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:5184px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/performance-lab-2015"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:61.007957458496094%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1449530995087-P37CRQ6XQR0MY4EK663I/26%2Bcolour-2.jpg" alt="26+colour-2.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1449530995087-P37CRQ6XQR0MY4EK663I/26%2Bcolour-2.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1449530995087-P37CRQ6XQR0MY4EK663I/26%2Bcolour-2.jpg" data-image-dimensions="5184x3456" data-image-focal-point="0.5,0.5526315789473685" alt="26+colour-2.jpg" data-load="false" data-image-id="56661649d8af105622ced5e5" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_6_1465255983598_476082"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="http://urbandreambrokerage.org.nz/performance-lab-2015"><strong>PROJECT #37: PERFORMANCE LAB</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Property Partner: Cook Strait Properties Ltd.&nbsp;1 Marjoribanks Street. 1 Dec 2015 - 11 Mar 2016. More information </strong><a href="http://urbandreambrokerage.org.nz/performance-lab-2015"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="61.24260355029586" data-block-type="5" id="block-yui_3_17_2_2_1433464947697_46542"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:800px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/sub-urban"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:61.24260330200195%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1439900988285-DJ4KML0LYWYUEUSD6YSX/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1439900988285-DJ4KML0LYWYUEUSD6YSX/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1439900988285-DJ4KML0LYWYUEUSD6YSX/image-asset.jpeg" data-image-dimensions="800x534" data-image-focal-point="0.5,1.0" alt="" data-load="false" data-image-id="55d3253ae4b075ba970771cb" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_6_1465255983598_201794"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/sub-urban"><strong>PROJECT #36:&nbsp;SUB URBAN CO-WORKING</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Property Partner: DNZ Property Fund Ltd. Johnsonville Shopping Centre. From 2 June 2015. More information </strong><a href="/sub-urban"><strong>here</strong></a><strong>.&nbsp;</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="60.47745358090185" data-block-type="5" id="block-yui_3_17_2_2_1433378292820_45592"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/wheel-of-justice"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:60.477455139160156%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1433378383266-L4VP76GCBDZTTQ09DO5P/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1433378383266-L4VP76GCBDZTTQ09DO5P/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1433378383266-L4VP76GCBDZTTQ09DO5P/image-asset.jpeg" data-image-dimensions="2500x1406" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="556f9e3de4b0b2df44546d8d" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_12_1456181556899_102027"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/wheel-of-justice"><strong>PROJECT #35: WHEEL OF JUSTICE</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Amnesty International New Zealand. Property Partner: Vicinity Ltd. 307 Willis Street, Wellington. 6 -7 June 2015. More information </strong><a href="/wheel-of-justice"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="60.946745562130175" data-block-type="5" id="block-yui_3_17_2_6_1431666384731_94119"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:800px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/surveillance-awareness-laboratory"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:60.946746826171875%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1432854777887-8HD5DFRGT0MYT1IBJGC5/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1432854777887-8HD5DFRGT0MYT1IBJGC5/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1432854777887-8HD5DFRGT0MYT1IBJGC5/image-asset.jpeg" data-image-dimensions="800x534" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="5567a0f8e4b07df22a1a5e00" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_6_1465255983598_309838"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/surveillance-awareness-laboratory"><strong>PROJECT #34: SURVEILLANCE AWARENESS BUREAU</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Modelab. Property partner: DNZ Property Ltd. 1 Grey Street. 27 May – 13 June. Wednesday–Friday 12–5pm, Saturday 12–3pm.&nbsp;More information </strong><a href="/surveillance-awareness-laboratory"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_2_1427415416694_66834"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:800px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/new-gallery-1"
+              target="_blank"
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.75%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1428451100855-CMAKX73JU02ZFPSN8T6P/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1428451100855-CMAKX73JU02ZFPSN8T6P/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1428451100855-CMAKX73JU02ZFPSN8T6P/image-asset.jpeg" data-image-dimensions="800x534" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="55246f1ae4b0fed3b8c51fc5" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_2_1427415416694_48440"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/new-gallery-1"><strong>Project #33: Laou </strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Nelio and Duncan Passmore. Property partner: Nidus Properties. Cnr Torrens and Webb Street. 28 March - 4 April 2015. More information </strong><a href="/new-gallery-1"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_7_1423789523782_40352"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1280px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/the-wet-index"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.71875%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1424817109534-8UMQ44E9LFUUJTBKX990/2R7A6255.jpeg" alt="2R7A6255.jpeg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1424817109534-8UMQ44E9LFUUJTBKX990/2R7A6255.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1424817109534-8UMQ44E9LFUUJTBKX990/2R7A6255.jpeg" data-image-dimensions="1280x854" data-image-focal-point="0.5,0.5" alt="2R7A6255.jpeg" data-load="false" data-image-id="54ecfbd3e4b0dc5d50456b50" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_7_1423789523782_53238"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/the-wet-index"><strong>PROJECT #32: THE WET INDEX</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Kedron Parker and Bruce McNaught. Property partner: Cornerstone Properties. 11 Woodward Street. From 16 February 2015. More information </strong><a href="/the-wet-index"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="66.79389312977099" data-block-type="5" id="block-yui_3_17_2_2_1421783472039_94263"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:960px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/performance-lab"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.79389190673828%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1423791370924-2RUST3Y5VIJCTJDBAQ4O/5photo.JPG" alt="5photo.JPG" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1423791370924-2RUST3Y5VIJCTJDBAQ4O/5photo.JPG" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1423791370924-2RUST3Y5VIJCTJDBAQ4O/5photo.JPG" data-image-dimensions="960x720" data-image-focal-point="0.5,0.5" alt="5photo.JPG" data-load="false" data-image-id="54dd5508e4b02586720e9bda" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_2_1421783472039_49372"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/performance-lab"><strong>PROJECT #31: PERFORMANCE LAB&nbsp;2014</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Performance Arcade. Property partner: Prime Property. 17 Whitmore Street. 22 December - 28 February 2015. More information </strong><a href="/performance-lab"><strong>here</strong></a><strong>. </strong></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="61.94690265486725" data-block-type="5" id="block-yui_3_17_2_7_1418763971386_44224"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/flow-chart"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:61.946903228759766%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1421980348591-E7D1R2LAU6VW5CHMEADW/P1030091.JPG" alt="P1030091.JPG" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1421980348591-E7D1R2LAU6VW5CHMEADW/P1030091.JPG" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1421980348591-E7D1R2LAU6VW5CHMEADW/P1030091.JPG" data-image-dimensions="2500x1405" data-image-focal-point="0.5,0.5" alt="P1030091.JPG" data-load="false" data-image-id="54c1b2b5e4b07b213a4687aa" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_7_1418763971386_152575"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/flow-chart">PROJECT #30: FLOW CHART</a></h3><p class="" style="white-space:pre-wrap;"><strong>Andrea Selwood. Property partner: Prime Property. Greenock House, 108 Lambton Quay. 24 December - 25 January 2015. More information </strong><a href="https://urbandreambrokerage.squarespace.com/flow-chart"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="61.834319526627226" data-block-type="5" id="block-yui_3_17_2_2_1418255333542_36968"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:640px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/the-colourists"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:61.834320068359375%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1418897401144-F4C3R7566J9JKN5D6AIZ/image.jpg" alt="image.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1418897401144-F4C3R7566J9JKN5D6AIZ/image.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1418897401144-F4C3R7566J9JKN5D6AIZ/image.jpg" data-image-dimensions="640x480" data-image-focal-point="0.5,0.5" alt="image.jpg" data-load="false" data-image-id="5492a7f9e4b07719aacc0125" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_2_1418255333542_48396"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="#">Project #29: The Colourists</a></h3><p class="" style="white-space:pre-wrap;"><strong>Sophia McKinnon. Property partner: Prime Property. Greenock House, 108 Lambton Quay</strong>.<strong> 15 - 20 December 2014. More information </strong><a href="/the-colourists"><strong>here</strong></a><strong>.&nbsp; </strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="61.834319526627226" data-block-type="5" id="block-yui_3_17_2_1_1417479520578_77045"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:800px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/concoction"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:61.834320068359375%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1418075758049-4QO22F4B74YFPWTDXKCH/Elbowroom_Concoction+Image.jpg" alt="Elbowroom_Concoction Image.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1418075758049-4QO22F4B74YFPWTDXKCH/Elbowroom_Concoction+Image.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1418075758049-4QO22F4B74YFPWTDXKCH/Elbowroom_Concoction+Image.jpg" data-image-dimensions="800x534" data-image-focal-point="0.5,0.5" alt="Elbowroom_Concoction Image.jpg" data-load="false" data-image-id="54861e6ee4b051cf8a8abb62" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_2_1418255333542_149708"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/concoction">Project #28: Concoction </a></h3><p class="" style="white-space:pre-wrap;"><strong>Elbowroom - The Moving Gallery. Property partner: Prime Property. 17 Whitmore Street. 7 - 14 December. More information </strong><a href="/concoction"><strong>here</strong></a><strong>. </strong></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="64.54545454545455" data-block-type="5" id="block-yui_3_17_2_1_1417592124246_86739"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:800px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/puta"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:64.54545593261719%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1425328225582-XLDRLJM7TRNE95BZUZ6E/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1425328225582-XLDRLJM7TRNE95BZUZ6E/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1425328225582-XLDRLJM7TRNE95BZUZ6E/image-asset.jpeg" data-image-dimensions="800x534" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="54f4c85fe4b08c831d3d93a0" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1417592124246_115053"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="#">Project #27: Puta</a></h3><p class="" style="white-space:pre-wrap;"><strong>Boys and Girls Institute. Chaffers Dock, 1 Herd Street. December 1 2014 – ongoing. Monday-Friday, 9-5pm.&nbsp; More information </strong><a href="/puta"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1413764194787_50285"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/free-yoga-day"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:64.12000274658203%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1413765639068-9SHTMC463ZW6THNT2XBB/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1413765639068-9SHTMC463ZW6THNT2XBB/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1413765639068-9SHTMC463ZW6THNT2XBB/image-asset.jpeg" data-image-dimensions="2500x1603" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="54445a07e4b0e6f12d4f832d" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1413764194787_59852"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/free-yoga-day">Project #26: Free Yoga Day</a></h3><p class="" style="white-space:pre-wrap;"><strong>Property Partner DNZ Property Ltd. 1 Grey Street. Labour Day, 27 October 2014. 7:30am - 9:30pm. For more information </strong><a href="http://freeyogaday.wix.com/wellington2014" target="_blank"><strong>go here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="64.30678466076697" data-block-type="5" id="block-yui_3_17_2_1_1412279815796_98931"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:800px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/homies-cosy-teahouse"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:64.3067855834961%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1418081137757-ZAZ14M9LKNYRUN29OT05/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1418081137757-ZAZ14M9LKNYRUN29OT05/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1418081137757-ZAZ14M9LKNYRUN29OT05/image-asset.jpeg" data-image-dimensions="800x534" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="54863371e4b033b4dc30e3b2" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1412279815796_287158"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="#">Project #25: Homies Cosy Teahouse&nbsp;</a></h3><p class="" style="white-space:pre-wrap;"><strong>Naomi Smith. Property Partner: Standard 806 Ltd. 90 Manners Street. From 6 October 2014. 10am - midnight, seven days. For more information go </strong><a href="/homies-cosy-teahouse"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1412279815796_300456"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:100%;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/vaudevillains-clubhouse"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.66667175292969%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1414094780526-RHW24IK55LNBV4C8U3RZ/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1414094780526-RHW24IK55LNBV4C8U3RZ/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1414094780526-RHW24IK55LNBV4C8U3RZ/image-asset.jpeg" data-image-dimensions="960x640" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="54495fbce4b06cde44f35d88" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1411004466496_39927"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:800px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/aura-secure"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.75%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1412137686093-NJ0TETZ5WE075JFDSWWY/AuraSecure-brochure+front.jpg" alt="AuraSecure-brochure front.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1412137686093-NJ0TETZ5WE075JFDSWWY/AuraSecure-brochure+front.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1412137686093-NJ0TETZ5WE075JFDSWWY/AuraSecure-brochure+front.jpg" data-image-dimensions="800x534" data-image-focal-point="0.5,0.5" alt="AuraSecure-brochure front.jpg" data-load="false" data-image-id="542b82d6e4b00f635c614579" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1411004466496_77520"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:100%;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/dirty-laundry"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.75%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1412136478357-LAPVXXOGDE9NPJY8NS9S/10616508_813110688711144_8646842810416095295_n.jpg" alt="10616508_813110688711144_8646842810416095295_n.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1412136478357-LAPVXXOGDE9NPJY8NS9S/10616508_813110688711144_8646842810416095295_n.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1412136478357-LAPVXXOGDE9NPJY8NS9S/10616508_813110688711144_8646842810416095295_n.jpg" data-image-dimensions="800x534" data-image-focal-point="0.5,0.5" alt="10616508_813110688711144_8646842810416095295_n.jpg" data-load="false" data-image-id="542b7e1ee4b05bfcb6d28dea" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1412279815796_347697"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="#">Project #24: Vaudevillains Clubhouse</a></h3><p class="" style="white-space:pre-wrap;"><strong>Vaudeville Inc. Property Partner:&nbsp;The Wellington Company. Left Bank, Cuba Mall. 17 October - 1 November. For more information go</strong><a href="/vaudevillains-clubhouse"><strong> here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1411004466496_45828"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="#">Project #22: AuraSecure</a></h3><p class="" style="white-space:pre-wrap;"><strong>Terri te Tau. Property Partner: DNZ Property Ltd.&nbsp; 1 Grey Street (across from Intercontinental Hotel). 27 September - 5 October 2014. More information </strong><a href="/aura-secure"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1411004466496_134503"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/dirty-laundry">Project #23: Dirty Laundry</a></h3><p class="" style="white-space:pre-wrap;"><strong>The Hori. Property Partner: Positively Wellington Tourism. 101 Wakefield Street (across from Lido Cafe). 27 September - 12 October. More information </strong><a href="/dirty-laundry"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="66.66666666666666" data-block-type="5" id="block-yui_3_17_2_1_1410392579849_100149"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:960px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/sounding-out-vacancy"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.66666412353516%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1417595213980-X12X4UV12EKYHO6DOYF8/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1417595213980-X12X4UV12EKYHO6DOYF8/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1417595213980-X12X4UV12EKYHO6DOYF8/image-asset.jpeg" data-image-dimensions="960x720" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="547ec94de4b04e450c94e0f8" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1410392579849_108632"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/sounding-out-vacancy">Project #21: Sounding Out Vacancy</a></h3><p class="" style="white-space:pre-wrap;"><strong>Julieanna Preston. Property Partner: DNZ Property Fund Ltd. 1 Grey Street, Wellington. 16 - 23 September. Closing 6-8pm 23 September. More information </strong><a href="/sounding-out-vacancy"><strong>here.</strong></a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="67.66169154228857" data-block-type="5" id="block-yui_3_17_2_1_1410392579849_45240"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/urban-bodies"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:67.66168975830078%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1410404243203-O7X63JDYBTZVV8H9D91Y/Urban+Bodies%2C+Morphic+Assemblies+space1.jpg" alt="Urban Bodies, Morphic Assemblies space1.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1410404243203-O7X63JDYBTZVV8H9D91Y/Urban+Bodies%2C+Morphic+Assemblies+space1.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1410404243203-O7X63JDYBTZVV8H9D91Y/Urban+Bodies%2C+Morphic+Assemblies+space1.jpg" data-image-dimensions="2500x1875" data-image-focal-point="0.5,0.5" alt="Urban Bodies, Morphic Assemblies space1.jpg" data-load="false" data-image-id="54110f93e4b06e9036eb5533" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1410392579849_54716"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/urban-bodies">Project #20: Urban Bodies</a></h3><p class="" style="white-space:pre-wrap;"><strong>Tomas Richards. Property Partner - Positively Wellington Tourism. 101 Wakefield Street (across from Lido Cafe). 14- 20 September 2014, 9am-5pm. More information </strong><a href="/urban-bodies"><strong>here</strong></a><strong> and </strong><a href="https://www.facebook.com/events/527597710673607/?fref=ts" target="_blank"><strong>here</strong></a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="66.16915422885572" data-block-type="5" id="block-yui_3_17_2_1_1409194059192_94943"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:800px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/political-cuts"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.16915130615234%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1409706273760-JSA6V002P90HLH7NXKUA/10498628_1541747852712103_6277194171646916141_o.jpg" alt="10498628_1541747852712103_6277194171646916141_o.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1409706273760-JSA6V002P90HLH7NXKUA/10498628_1541747852712103_6277194171646916141_o.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1409706273760-JSA6V002P90HLH7NXKUA/10498628_1541747852712103_6277194171646916141_o.jpg" data-image-dimensions="800x534" data-image-focal-point="0.5,0.5" alt="10498628_1541747852712103_6277194171646916141_o.jpg" data-load="false" data-image-id="54066921e4b017ae41b5738a" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1409194059192_102160"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/political-cuts" target="_blank">Project #19: Political Cuts</a></h3><p class="" style="white-space:pre-wrap;"><strong>Barbarian Productions. Property partner: Positively Wellington Tourism. 101 Wakefield Street (former Nui Cafe). 1-5 September. Project information and images</strong><a href="/political-cuts"><strong> here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1408530246843_288565"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:100%;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/imaginarium"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:74.90494537353516%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1409798572689-ZHHWTONZOYOB4ENV5H86/15-49-21_23-08-14.jpg" alt="15-49-21_23-08-14.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1409798572689-ZHHWTONZOYOB4ENV5H86/15-49-21_23-08-14.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1409798572689-ZHHWTONZOYOB4ENV5H86/15-49-21_23-08-14.jpg" data-image-dimensions="526x394" data-image-focal-point="0.5,0.5" alt="15-49-21_23-08-14.jpg" data-load="false" data-image-id="5407d1ace4b0ab37159a0be7" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1408530246843_234193"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/imaginarium">Project #18: Imaginarium</a></h3><p class="" style="white-space:pre-wrap;"><strong>Reading Cinema, Courtenay Place. Property partner: Reading Courtenay Central/ CBRE. 23 August - 15 September. 12-6pm Wednesday - Saturday. Project information&nbsp;</strong><a href="/imaginarium"><strong>here</strong></a><strong>. </strong></p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_10_1_1_1400714591905_40117"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:960px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/nothing-but-precious"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.04166412353516%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1401762420317-LDY6T03ZO9BE4MJ9LXGE/Mary+Whalley%2C+Carrying+piece%2C+Filmed+by+Jason+Wright%2C+2014.jpg" alt="Mary Whalley, Carrying piece, Filmed by Jason Wright, 2014.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1401762420317-LDY6T03ZO9BE4MJ9LXGE/Mary+Whalley%2C+Carrying+piece%2C+Filmed+by+Jason+Wright%2C+2014.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1401762420317-LDY6T03ZO9BE4MJ9LXGE/Mary+Whalley%2C+Carrying+piece%2C+Filmed+by+Jason+Wright%2C+2014.jpg" data-image-dimensions="960x634" data-image-focal-point="0.5,0.5" alt="Mary Whalley, Carrying piece, Filmed by Jason Wright, 2014.jpg" data-load="false" data-image-id="538d3274e4b08a8b36a0140e" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_10_1_1_1400714591905_46831"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/nothing-but-precious">Project #15: Nothing But Precious</a><a href="#"> &nbsp;</a></h3><p class="" style="white-space:pre-wrap;"><strong>Elbowroom - The Moving Gallery. Cnr Torrens Terrace and Webb Street. Property Partner:&nbsp;Nidus Properties Ltd. 28 May - 14 June 2014 .</strong> <a href="/nothing-but-precious">Project information here.</a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1408530246843_282234"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:960px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/long-cloud-theatre"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:75%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1410307968836-MTX8Y7TH2WG6WKYSQY0S/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1410307968836-MTX8Y7TH2WG6WKYSQY0S/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1410307968836-MTX8Y7TH2WG6WKYSQY0S/image-asset.jpeg" data-image-dimensions="960x720" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="540f9780e4b04939fb5b4b41" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1408530246843_88381"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/long-cloud-theatre">Project #17: Mountebank</a></h3><p class="" style="white-space:pre-wrap;"><strong>Long Cloud Youth Theatre. 109 Dixon Street. Property p: Overton Holdings/ Baileys Property Services Ltd. 4 - 12 September. Project information&nbsp;</strong><a href="/long-cloud-theatre"><strong>here</strong></a><strong>. Website&nbsp;</strong><a href="http://www.themountebank.co.nz" target="_blank"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_10_1_1_1400714591905_172406"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2000px;"
+        >
+          
+        
+        
+
+        
+          
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.75%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1400715664736-TDS102NBY13MFYHQ968K/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1400715664736-TDS102NBY13MFYHQ968K/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1400715664736-TDS102NBY13MFYHQ968K/image-asset.jpeg" data-image-dimensions="2000x1335" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="537d3990e4b0404fb5ca3e12" data-type="image" />
+                
+            </div>
+          </div>
+        
+          
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_10_1_1_1400714591905_204604"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/moodbank">Project #14: Moodbank&nbsp;</a></h3><p class="" style="white-space:pre-wrap;"><strong>Vanessa&nbsp;Crowe and Dr Sarah Baker. 29 Manners Street.&nbsp;Property Partner: Shoreline Property Group. March 2014.&nbsp;10am - 8pm.&nbsp;</strong><a href="/moodbank">Project information here.</a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1408530246843_272452"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:640px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/battle-hymn"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:75%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1410310704419-D5MYSVOPCGA9BBUYDJK0/14-36-43_07-08-14.jpg" alt="14-36-43_07-08-14.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1410310704419-D5MYSVOPCGA9BBUYDJK0/14-36-43_07-08-14.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1410310704419-D5MYSVOPCGA9BBUYDJK0/14-36-43_07-08-14.jpg" data-image-dimensions="640x480" data-image-focal-point="0.5,0.5" alt="14-36-43_07-08-14.jpg" data-load="false" data-image-id="540fa230e4b07898251f78ba" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1408530246843_79497"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/battle-hymn">Project #16:&nbsp;Battle Hymn</a></h3><p class="" style="white-space:pre-wrap;"><strong>Red Scare Collective.&nbsp;114 Cuba Street (Left Bank).&nbsp;Property partner: The Wellington Company.&nbsp;18 - 20 September 2014. Project information </strong><a href="/battle-hymn"><strong>here</strong></a><strong>. Production website&nbsp;</strong><a href="http://www.redscarecollective.com" target="_blank"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-ddccd67e34cba6cf2dac"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2000px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/the-waiting-room"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.75%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1400013799239-BJOQIW80E2PTSO5RBYC8/waiting-room.jpg" alt="waiting-room.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1400013799239-BJOQIW80E2PTSO5RBYC8/waiting-room.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1400013799239-BJOQIW80E2PTSO5RBYC8/waiting-room.jpg" data-image-dimensions="2000x1335" data-image-focal-point="0.5,0.5" alt="waiting-room.jpg" data-load="false" data-image-id="537283e7e4b0d7a46b2df057" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-c692e6d2200ff9867edd"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/the-waiting-room">Project #13: The Waiting Room</a></h3><p class="" style="white-space:pre-wrap;"><strong>Victoria Singh. 123 Cuba&nbsp;Street. Property Partner: Anonymous. March 2014. </strong><a href="/the-waiting-room">Project information here.</a></p>
+</div>
+
+
+
+</div></div></div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="76.5" data-block-type="5" id="block-81dcb03bfd2bb7230672"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:100%;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/midsummer"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:76.5%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1393556697240-C3HKUAP3ZT9NTFU9HP7I/IMG_0050.jpeg" alt="IMG_0050.jpeg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1393556697240-C3HKUAP3ZT9NTFU9HP7I/IMG_0050.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1393556697240-C3HKUAP3ZT9NTFU9HP7I/IMG_0050.jpeg" data-image-dimensions="800x534" data-image-focal-point="0.5,0.5" alt="IMG_0050.jpeg" data-load="false" data-image-id="530ffcd9e4b0aa9562867bd0" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="76" data-block-type="5" id="block-176f4a1172ae8c675cdf"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:100%;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          content-fill
+        
+              "
+              href="/java-dance"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          content-fill
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:76%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1390955903342-11LDAZ6U0BDKDB92IR1O/RISE-001.jpg" alt="RISE-001.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1390955903342-11LDAZ6U0BDKDB92IR1O/RISE-001.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1390955903342-11LDAZ6U0BDKDB92IR1O/RISE-001.jpg" data-image-dimensions="2500x1668" data-image-focal-point="0.5,0.5" alt="RISE-001.jpg" data-load="false" data-image-id="52e84d7fe4b04e00fe3465c5" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="74.5" data-block-type="5" id="block-41b025cd3cea3c2a2ffe"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:100%;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          content-fill
+        
+              "
+              href="/new-gallery"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          content-fill
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:74.5%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1382664004839-W36KV9EPWUMR3B7C84BV/13-23-27_23-10-13.jpg" alt="13-23-27_23-10-13.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1382664004839-W36KV9EPWUMR3B7C84BV/13-23-27_23-10-13.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1382664004839-W36KV9EPWUMR3B7C84BV/13-23-27_23-10-13.jpg" data-image-dimensions="800x600" data-image-focal-point="0.5,0.5" alt="13-23-27_23-10-13.jpg" data-load="false" data-image-id="5269c744e4b0eb2b76cc60a7" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-5b1d8e5e0ca06f98d6e2"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/midsummer">Project #12:&nbsp;A Midsummer Night's Dream</a></h3><p class="" style="white-space:pre-wrap;"><strong>A Bright Orange Walls Production.&nbsp;185 Victoria Street, Wellington.&nbsp;Property Partner: Portfolia. February 2014. </strong><a href="/midsummer">Information and images.&nbsp;</a></p><p class="" data-rte-preserve-empty="true" style="white-space:pre-wrap;"></p><p class="" data-rte-preserve-empty="true" style="white-space:pre-wrap;"></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-d778d134b5112e3acec2"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/java-dance">Project #11: Java Dance</a></h3><p class="" style="white-space:pre-wrap;"><strong>A Java Installation. 88-92 Riddford Street, Newtown. Property Partner: Mark Horsfall Properties. November 2013. </strong><a href="/java-dance">Information and images.</a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-0c673fd8a19ee55b3d4a"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/new-gallery">Project #10: Digital Biophilia</a></h3><p class="" style="white-space:pre-wrap;"><strong>Cnr Bowen St &amp; Lambton Quay. Property Partner: Bowen House Holdings Ltd. October 2013. </strong><a href="/new-gallery">Information and images.</a></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="67" data-block-type="5" id="block-9e6e19e779a576ecd95f"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:100%;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/broken-river"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:67%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1393557863951-O6NHIHT7BPZO6LL237WN/14-39-02_14-11-13.jpg" alt="14-39-02_14-11-13.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1393557863951-O6NHIHT7BPZO6LL237WN/14-39-02_14-11-13.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1393557863951-O6NHIHT7BPZO6LL237WN/14-39-02_14-11-13.jpg" data-image-dimensions="2500x1875" data-image-focal-point="0.5,0.5" alt="14-39-02_14-11-13.jpg" data-load="false" data-image-id="53100167e4b0e44d7fb20ddc" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-8df8f0d69f59fbadbcf9"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/broken-river">Project #9: Broken River</a></h3><p class="" style="white-space:pre-wrap;"><strong>Trick of the Light Theatre.&nbsp;Eagle Technology House, Victoria Street. October&nbsp;- December 2013.&nbsp;Property Partner: Oyster Group. </strong><a href="/broken-river">Information and images.</a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-ef4efd52e2da32cf1756"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:640px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/cleave"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.5625%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1379648261810-RED3PC85F553EDLXJ4QH/cleavehomepage.jpg" alt="cleavehomepage.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1379648261810-RED3PC85F553EDLXJ4QH/cleavehomepage.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1379648261810-RED3PC85F553EDLXJ4QH/cleavehomepage.jpg" data-image-dimensions="640x426" data-image-focal-point="0.5,0.5" alt="cleavehomepage.jpg" data-load="false" data-image-id="523bc305e4b0d4585704689c" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-5e54b2258f0cc5106125"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/cleave">Project #8: Cleave</a></h3><p class="" style="white-space:pre-wrap;"><strong>Gabby O'Connor.&nbsp;86 - 96 Victoria Street, Wellington.&nbsp;June - July 2013.&nbsp;Property Partner: Prime Property Group. </strong><a href="/cleave">Information and images.</a></p><p style="text-align:right;white-space:pre-wrap;" class="">&nbsp;</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-8ba4632edab8814c3a4f"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:100%;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/dying-city"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.40625%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1393558609213-ZAI590OYCN1B0CWWAM55/fc-20130612-00106-DSC_3586.jpg" alt="fc-20130612-00106-DSC_3586.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1393558609213-ZAI590OYCN1B0CWWAM55/fc-20130612-00106-DSC_3586.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1393558609213-ZAI590OYCN1B0CWWAM55/fc-20130612-00106-DSC_3586.jpg" data-image-dimensions="640x425" data-image-focal-point="0.5,0.5" alt="fc-20130612-00106-DSC_3586.jpg" data-load="false" data-image-id="53100451e4b0e44d7fb213c6" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-347821bea16b94495dde"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/dying-city">Project #7: Tales of a Dying City</a></h3><p class="" style="white-space:pre-wrap;"><strong>A Slightly&nbsp;Isolated&nbsp;Dog. Grand Arcade, Willis Street. June 2013.&nbsp;Property Partner: Grand Complex Properties/Jones Lang LeSalle. </strong><a href="/dying-city">Information and images.&nbsp;</a></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="75.5" data-block-type="5" id="block-19a2e467028bc1c95058"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          content-fill
+        
+              "
+              href="/occupation"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          content-fill
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:75.5%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1368585862982-JPMI79IS150QE5FJ8G0Y/P1060408.JPG" alt="P1060408.JPG" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1368585862982-JPMI79IS150QE5FJ8G0Y/P1060408.JPG" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1368585862982-JPMI79IS150QE5FJ8G0Y/P1060408.JPG" data-image-dimensions="2500x3333" data-image-focal-point="0.5,0.5" alt="P1060408.JPG" data-load="false" data-image-id="5192f686e4b0356188b80331" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-13c320bb63081676030b"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/occupation">Project #6: Occupation Artists</a></h3><p class="" style="white-space:pre-wrap;"><strong>Grand Arcade, Willis Street. June - November 2013.&nbsp;Property Partner: Grand Complex Properties Ltd / Jones Lang LeSalle. </strong><a href="/occupation">Information and images.</a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-8 span-8"><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="74.5" data-block-type="5" id="block-30568a84d5758f00d6ed"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:100%;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          content-fill
+        
+              "
+              href="/brides"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          content-fill
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:74.5%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1393560308725-XDOED9VU3PSZ62LID9JF/posing.JPG" alt="posing.JPG" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1393560308725-XDOED9VU3PSZ62LID9JF/posing.JPG" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1393560308725-XDOED9VU3PSZ62LID9JF/posing.JPG" data-image-dimensions="960x720" data-image-focal-point="0.5,0.5" alt="posing.JPG" data-load="false" data-image-id="53100af4e4b0fe3537f2d0d6" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-c541ea5b86a9e218e282"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/brides">Project #5: Brides<em>&nbsp;</em></a></h3><p class="" style="white-space:pre-wrap;"><strong>Bowen House, Cnr Lambton Quay and Bowen Street. April 2013. Property Partner: Bowen Holdings Ltd.</strong>&nbsp;<a href="#" target="_blank">Information and images.&nbsp;</a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="73.5" data-block-type="5" id="block-b525c5909d772ca34aac"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:100%;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          content-fill
+        
+              "
+              href="/peoples-cinema"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          content-fill
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:73.5%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1372390077909-E0RMRRIXCVYGD19KAILN/fc-20130617-00011-DSC_3732.jpg" alt="fc-20130617-00011-DSC_3732.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1372390077909-E0RMRRIXCVYGD19KAILN/fc-20130617-00011-DSC_3732.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1372390077909-E0RMRRIXCVYGD19KAILN/fc-20130617-00011-DSC_3732.jpg" data-image-dimensions="2500x1396" data-image-focal-point="0.5,0.5" alt="fc-20130617-00011-DSC_3732.jpg" data-load="false" data-image-id="51cd02bde4b00280d0e73836" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-ef274cca711e156c57e9"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/occupation">Project #4: People's Cinema&nbsp;</a></h3><p class="" style="white-space:pre-wrap;"><strong>57 Manners Street. From April 2013. Property Partner: The Wellington Company. </strong><a href="/peoples-cinema">Information and images.</a></p>
+</div>
+
+
+
+</div></div></div></div></div></div><div class="row sqs-row"><div class="col sqs-col-8 span-8"><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="74" data-block-type="5" id="block-e73c99e86b405ef3291b"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:100%;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          content-fill
+        
+              "
+              href="http://urbandreambrokerage.org.nz/blog/2013/2/8/a-slinky-a-treadmill-a-bat-a-record-player-a-pair-of-dice-and-a-foot-spa"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          content-fill
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:74%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1361926928644-GZZPRPY3PVE3I21MZJAO/status-quo.jpg" alt="status-quo.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1361926928644-GZZPRPY3PVE3I21MZJAO/status-quo.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1361926928644-GZZPRPY3PVE3I21MZJAO/status-quo.jpg" data-image-dimensions="615x427" data-image-focal-point="0.5,0.5" alt="status-quo.jpg" data-load="false" data-image-id="512d5b10e4b0fc5465700ffb" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-783a456dde7993409fb1"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:640px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          content-fill
+        
+              "
+              href="/your-message-here"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          content-fill
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:75%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1394567357225-RYRAGH1KQLYW8CS2ZGEH/daniel+and+kirsty.jpg" alt="daniel and kirsty.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1394567357225-RYRAGH1KQLYW8CS2ZGEH/daniel+and+kirsty.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1394567357225-RYRAGH1KQLYW8CS2ZGEH/daniel+and+kirsty.jpg" data-image-dimensions="640x480" data-image-focal-point="0.5,0.5" alt="daniel and kirsty.jpg" data-load="false" data-image-id="531f68bde4b094aec2540537" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div></div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-509b75a2be7127aa8ec9"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:100%;"
+        >
+          
+        
+        
+
+        
+          
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          content-fill
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:74.68000030517578%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1366153435811-AWYN9ZGXF6JYF8N1NP6P/IMG_0699.JPG" alt="IMG_0699.JPG" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1366153435811-AWYN9ZGXF6JYF8N1NP6P/IMG_0699.JPG" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1366153435811-AWYN9ZGXF6JYF8N1NP6P/IMG_0699.JPG" data-image-dimensions="2500x1867" data-image-focal-point="0.5,0.5" alt="IMG_0699.JPG" data-load="false" data-image-id="516dd8dbe4b005d966f8f0ab" data-type="image" />
+                
+            </div>
+          </div>
+        
+          
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-095c5a75c0d3fd8c2980"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/status-quo">Project #1: Status Quo</a></h3><p class="" style="white-space:pre-wrap;"><strong>James R Ford.&nbsp;120 Courtenay Place.&nbsp;February - March 2013. Property partner: Frank Wong on behalf of Wong Wung Partnership.</strong> <a href="/status-quo">Information and images.</a></p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_3_1457993876134_115776"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:620px;"
+        >
+          
+        
+        
+
+        
+          
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:61.29032516479492%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1457994012692-8K70U60DSX0TKTIF7NIT/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1457994012692-8K70U60DSX0TKTIF7NIT/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1457994012692-8K70U60DSX0TKTIF7NIT/image-asset.jpeg" data-image-dimensions="620x380" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="56e7391c62cd940c184b8018" data-type="image" />
+                
+            </div>
+          </div>
+        
+          
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1634179800233_264131"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/17-tory-street">PROJECT #0: 17 TORY STREET</a></h3><p class="" style="white-space:pre-wrap;">Concerned Citizens Collective. 17 Tory Street. April 2012 - ongoing. Property partner: Michael Baker. <a href="/17-tory-street">Information and images.</a></p><h3 style="white-space:pre-wrap;">&nbsp;</h3><p class="" style="white-space:pre-wrap;">&nbsp;</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-2fe3645d7f59dc0c9025"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/your-message-here">Project #2: Your Message Here</a></h3><p class="" style="white-space:pre-wrap;"><strong>Daniel Webby. 86-96 Victoria Street. March 2013. Property partner: Prime Property Group.</strong><a href="/your-message-here"> Information and images.</a></p><p class="" data-rte-preserve-empty="true" style="white-space:pre-wrap;"></p><p class="" style="white-space:pre-wrap;">&nbsp;</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-8e4e6be6e5d40df03cc4"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/serpent">Project #3:&nbsp;Scales of the Serpent</a></h3><p class="" style="white-space:pre-wrap;"><strong>Tessa Laird, March - May 2013. Opposite 19 Tory Street. Property partner: Reading Cinema and Care Park. </strong><a href="/serpent">Information and images.</a></p><p class="" style="white-space:pre-wrap;">&nbsp;</p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1634179800233_297969"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="text-align:center;white-space:pre-wrap;">Urban Dream Brokerage is run with the support of Wellington City Council and Wellington Community Trust</h3>
+</div>
+
+
+
+</div></div></div></div></div>
+
+    </section>
+
+    <div class="sqs-layout sqs-grid-12 columns-12 empty" data-layout-label="Footer Content: Home" data-type="block-field" data-updated-on="1606196528426" id="collection-508a094ee4b0f50834e1e3eb"><div class="row sqs-row"><div class="col sqs-col-12 span-12"></div></div></div>
+
+    <!-- <div class="page-divider bottom-divider"></div> -->
+
+    <div class="info-footer-wrapper clear">
+      <div class="info-footer">
+      <div class="sqs-layout sqs-grid-12 columns-12 empty" data-layout-label="Info Footer Content" data-type="block-field" id="infoFooterBlock"><div class="row sqs-row"><div class="col sqs-col-12 span-12"></div></div></div>
+      
+        
+        <div id="socialLinks" class="social-links" data-content-field="connected-accounts">
+          <a href="https://fb.me/e/3tDkNEgsf" target="_blank" class="social-facebook-unauth"></a>
+        </div>
+        
+      
+      </div>
+    </div>
+
+    <footer id="footer">
+      <div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Footer Content" data-type="block-field" data-updated-on="1676408954437" id="footerBlock"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="12.9973474801061" data-block-type="5" id="block-yui_3_17_2_2_1441141891441_4724"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:3212px;"
+        >
+          
+        
+        
+
+        
+          
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:12.997347831726074%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/42b7ab04-e3b7-4e9d-a305-2d4e6f822611/Aho+tini+banner.png" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/42b7ab04-e3b7-4e9d-a305-2d4e6f822611/Aho+tini+banner.png" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/42b7ab04-e3b7-4e9d-a305-2d4e6f822611/Aho+tini+banner.png" data-image-dimensions="3212x490" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="63ebf665946ad2337d39b900" data-type="image" />
+                
+            </div>
+          </div>
+        
+          
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="29.375" data-block-type="5" id="block-yui_3_17_2_2_1449541775858_9726"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:945px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="http://wellington.govt.nz"
+              target="_blank"
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:29.375%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/549b4846-d745-4e7d-88fa-504fb0b2ca64/WCC-Logo-Black-Web.png" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/549b4846-d745-4e7d-88fa-504fb0b2ca64/WCC-Logo-Black-Web.png" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/549b4846-d745-4e7d-88fa-504fb0b2ca64/WCC-Logo-Black-Web.png" data-image-dimensions="945x295" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="63ebf7c9964020555d2aebe8" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block socialaccountlinks-v2-block sqs-block-socialaccountlinks-v2" data-block-type="54" id="block-yui_3_17_2_1_1668570749464_18594"><div class="sqs-block-content">
+
+
+
+<div class="sqs-svg-icon--outer social-icon-alignment-center social-icons-color-black social-icons-size-large social-icons-shape-rounded social-icons-style-border" >
+  <style>
+    #block-yui_3_17_2_1_1668570749464_18594 .social-icons-style-border .sqs-svg-icon--wrapper {
+      
+        box-shadow: 0 0 0 2px inset;
+      
+      border: none; 
+    }
+  </style>
+  <nav class="sqs-svg-icon--list">
+    <a href="https://fb.me/e/3tDkNEgsf" target="_blank" class="sqs-svg-icon--wrapper facebook-unauth" aria-label="Facebook">
+      <div>
+        <svg class="sqs-svg-icon--social" viewBox="0 0 64 64">
+          <use class="sqs-use--icon" xlink:href="#facebook-unauth-icon"></use>
+          <use class="sqs-use--mask" xlink:href="#facebook-unauth-mask"></use>
+        </svg>
+      </div>
+    </a>
+  </nav>
+</div>
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="35.0132625994695" data-block-type="5" id="block-yui_3_17_2_3_1449529667690_6314"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1873px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="http://www.dunedin.govt.nz"
+              target="_blank"
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:35.01326370239258%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/dc1e60d4-9d9c-45b9-9c98-c6520db2dd96/CCS_logo_Wellington.jpg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/dc1e60d4-9d9c-45b9-9c98-c6520db2dd96/CCS_logo_Wellington.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/dc1e60d4-9d9c-45b9-9c98-c6520db2dd96/CCS_logo_Wellington.jpg" data-image-dimensions="1873x654" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="62cce39e77cebd1b0dfc616f" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div></div></div></div></div></div>
+    </footer>
+
+  </div>
+
+  <div></div>
+
+  <script data-sqs-type="imageloader-bootstrapper">if(window.ImageLoader) window.ImageLoader.bootstrap({}, document);</script><script>Squarespace.afterBodyLoad(Y);</script><svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="display:none" data-usage="social-icons-svg"><symbol id="facebook-unauth-icon" viewBox="0 0 64 64"><path d="M34.1,47V33.3h4.6l0.7-5.3h-5.3v-3.4c0-1.5,0.4-2.6,2.6-2.6l2.8,0v-4.8c-0.5-0.1-2.2-0.2-4.1-0.2 c-4.1,0-6.9,2.5-6.9,7V28H24v5.3h4.6V47H34.1z"/></symbol><symbol id="facebook-unauth-mask" viewBox="0 0 64 64"><path d="M0,0v64h64V0H0z M39.6,22l-2.8,0c-2.2,0-2.6,1.1-2.6,2.6V28h5.3l-0.7,5.3h-4.6V47h-5.5V33.3H24V28h4.6V24 c0-4.6,2.8-7,6.9-7c2,0,3.6,0.1,4.1,0.2V22z"/></symbol></svg>
+
+
+
+</body>
+
+</html>

--- a/src/test/resources/urbandreambrokerage_2.html
+++ b/src/test/resources/urbandreambrokerage_2.html
@@ -1,0 +1,10938 @@
+<!doctype html>
+<html xmlns:og="http://opengraphprotocol.org/schema/" xmlns:fb="http://www.facebook.com/2008/fbml" lang="en-US" >
+
+<head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  
+  <!-- This is Squarespace. --><!-- urbandreambrokerage -->
+<base href="">
+<meta charset="utf-8" />
+<title>Home &mdash; Urban Dream Brokerage</title>
+<meta http-equiv="Accept-CH" content="Sec-CH-UA-Platform-Version, Sec-CH-UA-Model" /><link rel="shortcut icon" type="image/x-icon" href="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1606292574122-SIWT4ES8XRH7GGCJQ7IR/favicon.ico?format=100w"/>
+<link rel="canonical" href="https://www.urbandreambrokerage.org.nz/home"/>
+<meta property="og:site_name" content="Urban Dream Brokerage"/>
+<meta property="og:title" content="Home &mdash; Urban Dream Brokerage"/>
+<meta property="og:url" content="https://www.urbandreambrokerage.org.nz/home"/>
+<meta property="og:type" content="website"/>
+<meta property="og:image" content="http://static1.squarespace.com/static/508a094ee4b0f50834e1e3d6/t/60bc7b8afd0e6f20d8fb2b35/1622965130730/Logo_Hero.jpg?format=1500w"/>
+<meta property="og:image:width" content="1500"/>
+<meta property="og:image:height" content="1000"/>
+<meta itemprop="name" content="Home — Urban Dream Brokerage"/>
+<meta itemprop="url" content="https://www.urbandreambrokerage.org.nz/home"/>
+<meta itemprop="thumbnailUrl" content="http://static1.squarespace.com/static/508a094ee4b0f50834e1e3d6/t/60bc7b8afd0e6f20d8fb2b35/1622965130730/Logo_Hero.jpg?format=1500w"/>
+<link rel="image_src" href="http://static1.squarespace.com/static/508a094ee4b0f50834e1e3d6/t/60bc7b8afd0e6f20d8fb2b35/1622965130730/Logo_Hero.jpg?format=1500w" />
+<meta itemprop="image" content="http://static1.squarespace.com/static/508a094ee4b0f50834e1e3d6/t/60bc7b8afd0e6f20d8fb2b35/1622965130730/Logo_Hero.jpg?format=1500w"/>
+<meta name="twitter:title" content="Home — Urban Dream Brokerage"/>
+<meta name="twitter:image" content="http://static1.squarespace.com/static/508a094ee4b0f50834e1e3d6/t/60bc7b8afd0e6f20d8fb2b35/1622965130730/Logo_Hero.jpg?format=1500w"/>
+<meta name="twitter:url" content="https://www.urbandreambrokerage.org.nz/home"/>
+<meta name="twitter:card" content="summary"/>
+<meta name="description" content="" />
+<link rel="preconnect" href="https://images.squarespace-cdn.com">
+<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Varela+Round:wght@400">
+<script type="text/javascript" crossorigin="anonymous" nomodule="nomodule" src="//assets.squarespace.com/@sqs/polyfiller/1.6/legacy.js"></script>
+<script type="text/javascript" crossorigin="anonymous" src="//assets.squarespace.com/@sqs/polyfiller/1.6/modern.js"></script>
+<script type="text/javascript">SQUARESPACE_ROLLUPS = {};</script>
+<script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/extract-css-runtime-a26782c50246ca1f7fe53-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-extract_css_runtime');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/extract-css-runtime-a26782c50246ca1f7fe53-min.en-US.js" ></script><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/extract-css-moment-js-vendor-5082e2dab696b020ac83a-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-extract_css_moment_js_vendor');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/extract-css-moment-js-vendor-5082e2dab696b020ac83a-min.en-US.js" ></script><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/cldr-resource-pack-bdc20c1f20167de1fe7a8-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-cldr_resource_pack');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/cldr-resource-pack-bdc20c1f20167de1fe7a8-min.en-US.js" ></script><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/common-vendors-stable-ded59447778e1491d87fa-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-common_vendors_stable');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/common-vendors-stable-ded59447778e1491d87fa-min.en-US.js" ></script><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/common-vendors-3d18b3c0a49a86aac406a-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-common_vendors');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/common-vendors-3d18b3c0a49a86aac406a-min.en-US.js" ></script><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/common-9317a25611c8280141cd2-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-common');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/common-9317a25611c8280141cd2-min.en-US.js" ></script><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/commerce-df15a9dc16608254b448c-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-commerce');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/commerce-df15a9dc16608254b448c-min.en-US.js" ></script><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].css = ["//assets.squarespace.com/universal/styles-compressed/commerce-42e904b2189a7c1684dd6-min.en-US.css"]; })(SQUARESPACE_ROLLUPS, 'squarespace-commerce');</script>
+<link rel="stylesheet" type="text/css" href="//assets.squarespace.com/universal/styles-compressed/commerce-42e904b2189a7c1684dd6-min.en-US.css"><script>(function(rollups, name) { if (!rollups[name]) { rollups[name] = {}; } rollups[name].js = ["//assets.squarespace.com/universal/scripts-compressed/performance-94cf07515a477394ca102-min.en-US.js"]; })(SQUARESPACE_ROLLUPS, 'squarespace-performance');</script>
+<script crossorigin="anonymous" src="//assets.squarespace.com/universal/scripts-compressed/performance-94cf07515a477394ca102-min.en-US.js" defer ></script><script data-name="static-context">Static = window.Static || {}; Static.SQUARESPACE_CONTEXT = {"facebookAppId":"314192535267336","facebookApiVersion":"v6.0","rollups":{"squarespace-announcement-bar":{"js":"//assets.squarespace.com/universal/scripts-compressed/announcement-bar-4cc0b4d80b66f7882d828-min.en-US.js"},"squarespace-audio-player":{"css":"//assets.squarespace.com/universal/styles-compressed/audio-player-702bf18174efe0acaa8ce-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/audio-player-2b5fae7c9343044e41bc5-min.en-US.js"},"squarespace-blog-collection-list":{"css":"//assets.squarespace.com/universal/styles-compressed/blog-collection-list-3d55c64c25996c7633fc2-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/blog-collection-list-94d73863f597285f58c6a-min.en-US.js"},"squarespace-calendar-block-renderer":{"css":"//assets.squarespace.com/universal/styles-compressed/calendar-block-renderer-49c4a5f3dae67a728e3f4-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/calendar-block-renderer-6274bd6025856331a1212-min.en-US.js"},"squarespace-chartjs-helpers":{"css":"//assets.squarespace.com/universal/styles-compressed/chartjs-helpers-53c004ac7d4bde1c92e38-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/chartjs-helpers-58511b8e7958d86dcf350-min.en-US.js"},"squarespace-comments":{"css":"//assets.squarespace.com/universal/styles-compressed/comments-cb7553e34a4da425817c4-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/comments-4ce868fede71369781f8f-min.en-US.js"},"squarespace-custom-css-popup":{"css":"//assets.squarespace.com/universal/styles-compressed/custom-css-popup-1364ee7f064caef6cd5e3-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/custom-css-popup-95747368669733868cb02-min.en-US.js"},"squarespace-dialog":{"css":"//assets.squarespace.com/universal/styles-compressed/dialog-9d9d0e960227d34faac26-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/dialog-de1c6c0dd4199a44b77c0-min.en-US.js"},"squarespace-events-collection":{"css":"//assets.squarespace.com/universal/styles-compressed/events-collection-49c4a5f3dae67a728e3f4-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/events-collection-47a74d5cbe64312b5ae05-min.en-US.js"},"squarespace-form-rendering-utils":{"js":"//assets.squarespace.com/universal/scripts-compressed/form-rendering-utils-e50512b2a29759d8593fa-min.en-US.js"},"squarespace-forms":{"css":"//assets.squarespace.com/universal/styles-compressed/forms-4a16a8a8c965386db2173-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/forms-4662919b5774cc3096d43-min.en-US.js"},"squarespace-gallery-collection-list":{"css":"//assets.squarespace.com/universal/styles-compressed/gallery-collection-list-3d55c64c25996c7633fc2-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/gallery-collection-list-80bfda88034d1e2f95767-min.en-US.js"},"squarespace-image-zoom":{"css":"//assets.squarespace.com/universal/styles-compressed/image-zoom-3d55c64c25996c7633fc2-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/image-zoom-b56ca0b7347a780ce9521-min.en-US.js"},"squarespace-pinterest":{"css":"//assets.squarespace.com/universal/styles-compressed/pinterest-3d55c64c25996c7633fc2-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/pinterest-444c7ffc9caa7a25e93e2-min.en-US.js"},"squarespace-popup-overlay":{"css":"//assets.squarespace.com/universal/styles-compressed/popup-overlay-948192219c3257f767ec5-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/popup-overlay-dd90d81250b91247d1b41-min.en-US.js"},"squarespace-product-quick-view":{"css":"//assets.squarespace.com/universal/styles-compressed/product-quick-view-4a16a8a8c965386db2173-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/product-quick-view-89dad1e5d16fbdf6f216a-min.en-US.js"},"squarespace-products-collection-item-v2":{"css":"//assets.squarespace.com/universal/styles-compressed/products-collection-item-v2-3d55c64c25996c7633fc2-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/products-collection-item-v2-6bc58c99783f0bbc14f30-min.en-US.js"},"squarespace-products-collection-list-v2":{"css":"//assets.squarespace.com/universal/styles-compressed/products-collection-list-v2-3d55c64c25996c7633fc2-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/products-collection-list-v2-239ed1ac3377d9ad03fd6-min.en-US.js"},"squarespace-search-page":{"css":"//assets.squarespace.com/universal/styles-compressed/search-page-9d0a55de1efafbb9218e1-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/search-page-22429c707cbc886be9d07-min.en-US.js"},"squarespace-search-preview":{"js":"//assets.squarespace.com/universal/scripts-compressed/search-preview-bd369c5c28c06a48bc9c7-min.en-US.js"},"squarespace-simple-liking":{"css":"//assets.squarespace.com/universal/styles-compressed/simple-liking-ef94529873378652e6e86-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/simple-liking-fdae2d43d38af1cfe236b-min.en-US.js"},"squarespace-social-buttons":{"css":"//assets.squarespace.com/universal/styles-compressed/social-buttons-1f18e025ea682ade6293a-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/social-buttons-c3728006cef46b677b94c-min.en-US.js"},"squarespace-tourdates":{"css":"//assets.squarespace.com/universal/styles-compressed/tourdates-3d55c64c25996c7633fc2-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/tourdates-f33fa1ab1bd26beecb665-min.en-US.js"},"squarespace-website-overlays-manager":{"css":"//assets.squarespace.com/universal/styles-compressed/website-overlays-manager-7cecc648f858e6f692130-min.en-US.css","js":"//assets.squarespace.com/universal/scripts-compressed/website-overlays-manager-b3d0b9344399a032ec974-min.en-US.js"}},"pageType":2,"website":{"id":"508a094ee4b0f50834e1e3d6","identifier":"urbandreambrokerage","websiteType":1,"contentModifiedOn":1685323414714,"cloneable":false,"hasBeenCloneable":false,"siteStatus":{},"language":"en-US","timeZone":"Pacific/Wake","machineTimeZoneOffset":43200000,"timeZoneOffset":43200000,"timeZoneAbbr":"WAKT","siteTitle":"Urban Dream Brokerage","fullSiteTitle":"Home \u2014 Urban Dream Brokerage","siteTagLine":"Space for new ideas in Wellington Te Whanganui \u0101 Tara","siteDescription":"<p>Nau mai Haere mai.&nbsp;<span>Urban Dream Brokerage provides space for new ideas in Wellington Te Whanganui </span>\u0101&nbsp;T<span>ara. Working with property managers, individuals and community groups UDB brokers the temporary use of vacant space for innovative projects, assisting in urban revitalisation. It is run by organisation</span><a target=\"_blank\" href=\"http://www.lettingspace.org.nz/\">&nbsp;</a><a target=\"_blank\" href=\"http://www.lettingspace.org.nz/\">Letting Space</a><span>.</span></p>","location":{"mapZoom":12.0,"mapLat":-41.2864603,"mapLng":174.77623600000004,"markerLat":-41.29521159999999,"markerLng":174.7801541,"addressTitle":"Urban Dream Brokerage","addressLine1":"Ground floor, 19 Tory Street","addressLine2":"Wellington city","addressCountry":"New Zealand"},"logoImageId":"6396af1a4be5de371da80152","socialLogoImageId":"60bc7b8afd0e6f20d8fb2b35","shareButtonOptions":{"3":true,"7":true,"4":true,"6":true,"8":true},"logoImageUrl":"//images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/e7e423b2-7ffb-490d-8d9c-8a8b9c2f8c21/UDB-Banner-116.png","socialLogoImageUrl":"//images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/567f5fc9-036c-4c3e-a281-5434e0435485/Logo_Hero.jpg","authenticUrl":"https://www.urbandreambrokerage.org.nz","internalUrl":"https://urbandreambrokerage.squarespace.com","baseUrl":"https://www.urbandreambrokerage.org.nz","primaryDomain":"www.urbandreambrokerage.org.nz","sslSetting":3,"isHstsEnabled":true,"socialAccounts":[{"serviceId":60,"screenname":"Facebook","addedOn":1682996435601,"profileUrl":"https://fb.me/e/3tDkNEgsf","iconEnabled":true,"serviceName":"facebook-unauth"}],"typekitId":"","statsMigrated":true,"imageMetadataProcessingEnabled":false,"screenshotId":"5053e56e","captchaSettings":{"enabledForDonations":false},"showOwnerLogin":false},"websiteSettings":{"id":"508a094ee4b0f50834e1e3d7","websiteId":"508a094ee4b0f50834e1e3d6","type":"Non-Profit","subjects":[{"systemSubject":"other","otherSubject":"Design/Art"}],"country":"NZ","state":"","simpleLikingEnabled":true,"mobileInfoBarSettings":{"isContactEmailEnabled":false,"isContactPhoneNumberEnabled":false,"isLocationEnabled":false,"isBusinessHoursEnabled":false},"commentLikesAllowed":true,"commentAnonAllowed":true,"commentThreaded":true,"commentApprovalRequired":false,"commentAvatarsOn":true,"commentSortType":2,"commentFlagThreshold":0,"commentFlagsAllowed":true,"commentEnableByDefault":true,"commentDisableAfterDaysDefault":0,"disqusShortname":"","commentsEnabled":true,"storeSettings":{"returnPolicy":null,"termsOfService":null,"privacyPolicy":null,"expressCheckout":true,"continueShoppingLinkUrl":"/","useLightCart":false,"showNoteField":false,"shippingCountryDefaultValue":"NZ","billToShippingDefaultValue":false,"showShippingPhoneNumber":true,"isShippingPhoneRequired":false,"showBillingPhoneNumber":true,"isBillingPhoneRequired":false,"currenciesSupported":["USD","ARS","AUD","BRL","CAD","CHF","COP","CZK","DKK","EUR","GBP","HKD","IDR","ILS","INR","JPY","MXN","MYR","NOK","NZD","PHP","PLN","RUB","SEK","SGD","THB","ZAR"],"defaultCurrency":"NZD","selectedCurrency":"NZD","measurementStandard":1,"showCustomCheckoutForm":false,"checkoutPageMarketingOptInEnabled":false,"enableMailingListOptInByDefault":false,"sameAsRetailLocation":false,"merchandisingSettings":{"scarcityEnabledOnProductItems":false,"scarcityEnabledOnProductBlocks":false,"scarcityMessageType":"DEFAULT_SCARCITY_MESSAGE","scarcityThreshold":10,"multipleQuantityAllowedForServices":true,"restockNotificationsEnabled":false,"restockNotificationsMailingListSignUpEnabled":false,"relatedProductsEnabled":false,"relatedProductsOrdering":"random","customSoldOutText":"Out Now","soldOutVariantsDropdownDisabled":true,"productComposerOptedIn":false,"productComposerABTestOptedOut":false,"productReviewsEnabled":false,"displayImportedProductReviewsEnabled":false,"hasOptedToCollectNativeReviews":false},"isLive":true,"multipleQuantityAllowedForServices":true},"useEscapeKeyToLogin":true,"ssBadgeType":1,"ssBadgePosition":4,"ssBadgeVisibility":1,"ssBadgeDevices":1,"pinterestOverlayOptions":{"mode":"disabled"},"ampEnabled":true},"cookieSettings":{"isCookieBannerEnabled":false,"isRestrictiveCookiePolicyEnabled":false,"isRestrictiveCookiePolicyAbsolute":false,"cookieBannerText":"","cookieBannerTheme":"","cookieBannerVariant":"","cookieBannerPosition":"","cookieBannerCtaVariant":"","cookieBannerCtaText":"","cookieBannerAcceptType":"OPT_IN","cookieBannerOptOutCtaText":""},"websiteCloneable":false,"collection":{"title":"Home","id":"508a094ee4b0f50834e1e3eb","fullUrl":"/home","publicCommentCount":0,"type":10,"permissionType":1},"subscribed":false,"appDomain":"squarespace.com","templateTweakable":true,"tweakJSON":{"outerPadding":"55px","pagePadding":"47px","product-gallery-auto-crop":"false","product-image-auto-crop":"true","topPadding":"35px","tweak-v1-related-products-title-spacing":"50px"},"templateId":"50749216e4b0933ed3da0a8d","templateVersion":"7","pageFeatures":[1,2,4],"gmRenderKey":"QUl6YVN5Q0JUUk9xNkx1dkZfSUUxcjQ2LVQ0QWVUU1YtMGQ3bXk4","templateScriptsRootUrl":"https://static1.squarespace.com/static/ta/5074801ae4b0933ed3d9d554/683/scripts/","betaFeatureFlags":["fluid_engine_clean_up_grid_contextual_change","accounting_orders_sync","campaigns_import_discounts","customer_accounts_email_verification","scripts_defer","crm_remove_subscriber","marketing_landing_page","commerce_etsy_shipping_import","site_user_email_change","fluid_engine","crm_enforce_recaptcha_v3_enterprise","viewer-role-contributor-invites","campaigns_global_uc_ab","commerce_site_visitor_metrics","campaigns_show_featured_templates","campaigns_asset_picker","is_feature_gate_refresh_enabled","crm_waitlist_enforce_recaptcha_v3_enterprise","campaigns_new_image_layout_picker","commerce_order_status_access","background_art_onboarding","multilingual_transactional_emails","crm_retention_segment","send_local_pickup_ready_email","commerce_restock_notifications","visitor_react_forms","crm_default_newsletter_block_to_campaigns","commerce_clearpay","commerce_etsy_product_import","campaigns_discount_section_in_blasts","nested_categories_migration_enabled","crm_enable_recaptcha_v3_enterprise","customer_account_creation_recaptcha","campaigns_discount_section_in_automations","member_areas_provisioning_service","campaigns_thumbnail_layout","order_status_page_checkout_landing_enabled","campaigns_content_editing_survey","member_areas_schedule_interview","member_areas_spanish_interviews"],"videoAssetsFeatureFlags":["mux-data-video-collection","mux-data-video-block","mux-data-course-collection"],"impersonatedSession":false,"tzData":{"zones":[[720,null,"+12",null]],"rules":{}},"showAnnouncementBar":false,"recaptchaEnterpriseContext":{"recaptchaEnterpriseSiteKey":"6LdDFQwjAAAAAPigEvvPgEVbb7QBm-TkVJdDTlAv"},"i18nContext":{"timeZoneData":{"id":"Pacific/Wake","name":"Wake Island Time"}}};</script><script>SquarespaceFonts.loadViaContext(); Squarespace.load(window);</script>
+<script type="application/ld+json">{"url":"https://www.urbandreambrokerage.org.nz","name":"Urban Dream Brokerage","description":"<p>Nau mai Haere mai.&nbsp;<span>Urban Dream Brokerage provides space for new ideas in Wellington Te Whanganui </span>\u0101&nbsp;T<span>ara. Working with property managers, individuals and community groups UDB brokers the temporary use of vacant space for innovative projects, assisting in urban revitalisation. It is run by organisation</span><a target=\"_blank\" href=\"http://www.lettingspace.org.nz/\">&nbsp;</a><a target=\"_blank\" href=\"http://www.lettingspace.org.nz/\">Letting Space</a><span>.</span></p>","image":"//images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/e7e423b2-7ffb-490d-8d9c-8a8b9c2f8c21/UDB-Banner-116.png","@context":"http://schema.org","@type":"WebSite"}</script><script type="application/ld+json">{"legalName":"Urban Dream Brokerage","address":"Ground floor, 19 Tory Street\nWellington city\nNew Zealand","email":"urbandreambrokerage@gmail.com","sameAs":["https://fb.me/e/3tDkNEgsf"],"@context":"http://schema.org","@type":"Organization"}</script><script type="application/ld+json">{"address":"Ground floor, 19 Tory Street\nWellington city\nNew Zealand","image":"https://static1.squarespace.com/static/508a094ee4b0f50834e1e3d6/t/6396af1a4be5de371da80152/1685323414714/","name":"Urban Dream Brokerage","@context":"http://schema.org","@type":"LocalBusiness"}</script><link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/sitecss/508a094ee4b0f50834e1e3d6/95/50749216e4b0933ed3da0a8d/508a094fe4b0f50834e1e58b/683/site.css"/><script src="//uploader.squarewebsites.org/sqs-form-upload.min.js"></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
+<script>!function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';n.agent='plsquarespace';n.queue=[];t=b.createElement(e);t.async=!0;t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,document,'script','https://connect.facebook.net/en_US/fbevents.js');fbq('init', '377306786857519');fbq('track', "PageView");</script><!-- End of Squarespace Headers -->
+  <script src="https://static1.squarespace.com/static/ta/5074801ae4b0933ed3d9d554/683/scripts/core-0.2.0.min.js" type="text/javascript"></script>
+  <script type="text/javascript" src="https://static1.squarespace.com/static/ta/5074801ae4b0933ed3d9d554/683/scripts/combo/?dynamic-data.js&site.js"></script>
+  
+</head>
+
+<body class="page-borders-thin canvas-style-normal  header-subtitle-none banner-alignment-center blog-layout-right-sidebar project-layout-left-sidebar thumbnails-on-open-page-show-all social-icon-style-round  hide-info-footer hide-page-banner    hide-article-author    event-thumbnails event-thumbnail-size-32-standard event-date-label event-date-label-time event-list-show-cats event-list-date event-list-time event-list-address   event-icalgcal-links  event-excerpts  event-item-back-link    product-list-titles-under product-list-alignment-center product-item-size-11-square product-image-auto-crop product-gallery-size-11-square  show-product-price show-product-item-nav product-social-sharing tweak-v1-related-products-image-aspect-ratio-11-square tweak-v1-related-products-details-alignment-center newsletter-style-dark  opentable-style-light small-button-style-solid small-button-shape-square medium-button-style-solid medium-button-shape-square large-button-style-solid large-button-shape-square image-block-poster-text-alignment-center  image-block-card-content-position-center image-block-card-text-alignment-opposite image-block-overlap-dynamic-font-sizing image-block-overlap-content-position-center image-block-overlap-text-alignment-left image-block-collage-dynamic-font-sizing image-block-collage-content-position-top image-block-collage-text-alignment-left image-block-stack-dynamic-font-sizing image-block-stack-text-alignment-left button-style-outline button-corner-style-square tweak-product-quick-view-button-style-floating tweak-product-quick-view-button-position-bottom tweak-product-quick-view-lightbox-excerpt-display-truncate tweak-product-quick-view-lightbox-show-arrows tweak-product-quick-view-lightbox-show-close-button tweak-product-quick-view-lightbox-controls-weight-light native-currency-code-nzd collection-508a094ee4b0f50834e1e3eb collection-type-page collection-layout-default mobile-style-available logo-image" id="collection-508a094ee4b0f50834e1e3eb">
+
+  <div id="canvas">
+
+    <div id="mobileNav" class="">
+      <div class="wrapper">
+        <nav class="main-nav mobileNav"><ul>
+  
+
+        
+
+          
+
+            <li class="page-collection">
+
+              
+                <a href="/about">UDB</a>
+              
+
+              
+
+            </li>
+
+          
+
+            <li class="page-collection">
+
+              
+                <a href="/book">Brokered Dreams - The Book</a>
+              
+
+              
+
+            </li>
+
+          
+
+        
+
+      
+
+  
+
+        
+
+          <li class=" external-link">
+
+            
+
+            
+              <a href="/home">Activations</a>
+            
+
+          </li>
+
+        
+
+      
+
+  
+
+        
+
+          
+
+            <li class="page-collection">
+
+              
+                <a href="/process-2022">Process</a>
+              
+
+              
+
+            </li>
+
+          
+
+            <li class="page-collection">
+
+              
+                <a href="/criteria-2022">Criteria</a>
+              
+
+              
+
+            </li>
+
+          
+
+            <li class="page-collection">
+
+              
+                <a href="/apply">Apply</a>
+              
+
+              
+
+            </li>
+
+          
+
+        
+
+      
+
+  
+
+        
+
+          <li class="page-collection">
+
+            
+              <a href="/got-a-property">Property</a>
+            
+
+            
+
+          </li>
+
+        
+
+      
+
+  
+
+        
+
+          <li class="page-collection">
+
+            
+              <a href="/blog_1">Blog</a>
+            
+
+            
+
+          </li>
+
+        
+
+      
+
+  
+
+        
+
+          
+
+            <li class="page-collection">
+
+              
+                <a href="/contact">Contact</a>
+              
+
+              
+
+            </li>
+
+          
+
+            <li class="page-collection">
+
+              
+                <a href="/subscribe">Subscribe</a>
+              
+
+              
+
+            </li>
+
+          
+
+        
+
+      
+
+  
+</ul>
+</nav>
+      </div>
+    </div>
+    <div id="mobileMenuLink"><a>Menu</a></div>
+
+    <header id="header" data-content-field="site-title" class="clear">
+
+    
+
+      <div id="upper-logo">
+        <h1 class="logo"><a href="/"><img src="//images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/e7e423b2-7ffb-490d-8d9c-8a8b9c2f8c21/UDB-Banner-116.png?format=1500w" alt="Urban Dream Brokerage" /></a></h1>
+      </div>
+      <script type="module">
+        Y.use('squarespace-ui-base', function(Y) {
+          Y.one("#upper-logo .logo").plug(Y.Squarespace.TextShrink, {
+            parentEl: Y.one('#upper-logo')
+          });
+        });
+      </script>
+
+      
+      <div class="site-info">
+        <div class="site-address">Ground floor, 19 Tory Street</div>
+        <div class="site-city-state">Wellington city</div>
+        <div class="site-phone">Phone Number</div>
+      </div>
+      
+
+      <div class="site-tag-line">
+        <span>Space for new ideas in Wellington Te Whanganui ā Tara</span>
+      </div>
+
+      <div class="custom-info">
+        <div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Header Subtitle: Custom Content" data-type="block-field" data-updated-on="1350505672216" id="customInfoBlock"><div class="row sqs-row"><div class="col sqs-col-11 span-11"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-1b7f9ceb68a0d033e896"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <p class="text-align-left">Your Custom Text Goes Here</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-1 span-1"><div class="sqs-block search-block sqs-block-search" data-block-type="33" id="block-9c9009ce87cd31ce1514"><div class="sqs-block-content">
+
+<div class="sqs-search-ui-text-input sqs-search-ui-button-wrapper color-dark" data-source="block" data-preview="false" data-collection="">
+  <div class="spinner-wrapper"></div>
+  <input
+    type="search"
+    class="search-input"
+    value=""
+    placeholder="Search"
+    aria-label="Search"
+  />
+</div>
+</div></div></div></div></div>
+      </div>
+
+      <div id="lower-logo">
+        <h1 class="logo"><a href="/"><img src="//images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/e7e423b2-7ffb-490d-8d9c-8a8b9c2f8c21/UDB-Banner-116.png?format=1500w" alt="Urban Dream Brokerage" /></a></h1>
+      </div>
+      <script type="module">
+        Y.use('squarespace-ui-base', function(Y) {
+          Y.one("#lower-logo .logo").plug(Y.Squarespace.TextShrink, {
+            parentEl: Y.one('#lower-logo')
+          });
+        });
+      </script>
+
+    
+      <div id="topNav">
+  <nav class="main-nav" data-content-field="navigation">
+    <ul>
+    
+
+        <li class="folder-collection folder">
+
+          
+
+            <a aria-haspopup="true" >About</a>
+            <div class="subnav">
+              <ul>
+                
+                  
+                    <li class="page-collection">
+                      <a href="/about">UDB</a>
+                    </li>
+                  
+                  
+                
+                  
+                    <li class="page-collection">
+                      <a href="/book">Brokered Dreams - The Book</a>
+                    </li>
+                  
+                  
+                
+              </ul>
+            </div>
+
+          
+
+        </li>
+
+    
+
+        <li class=" external-link">
+
+          
+
+            
+
+            
+              <a href="/home">Activations</a>
+            
+
+
+          
+
+        </li>
+
+    
+
+        <li class="folder-collection folder">
+
+          
+
+            <a aria-haspopup="true" >Opportunities</a>
+            <div class="subnav">
+              <ul>
+                
+                  
+                    <li class="page-collection">
+                      <a href="/process-2022">Process</a>
+                    </li>
+                  
+                  
+                
+                  
+                    <li class="page-collection">
+                      <a href="/criteria-2022">Criteria</a>
+                    </li>
+                  
+                  
+                
+                  
+                    <li class="page-collection">
+                      <a href="/apply">Apply</a>
+                    </li>
+                  
+                  
+                
+              </ul>
+            </div>
+
+          
+
+        </li>
+
+    
+
+        <li class="page-collection">
+
+          
+
+            
+              <a href="/got-a-property">Property</a>
+            
+
+            
+
+
+          
+
+        </li>
+
+    
+
+        <li class="page-collection">
+
+          
+
+            
+              <a href="/blog_1">Blog</a>
+            
+
+            
+
+
+          
+
+        </li>
+
+    
+
+        <li class="folder-collection folder">
+
+          
+
+            <a aria-haspopup="true" >Contact</a>
+            <div class="subnav">
+              <ul>
+                
+                  
+                    <li class="page-collection">
+                      <a href="/contact">Contact</a>
+                    </li>
+                  
+                  
+                
+                  
+                    <li class="page-collection">
+                      <a href="/subscribe">Subscribe</a>
+                    </li>
+                  
+                  
+                
+              </ul>
+            </div>
+
+          
+
+        </li>
+
+    
+  </ul>
+  <div class="page-divider"></div>
+  </nav>
+</div>
+
+
+    </header>
+
+    <div class="page-divider top-divider"></div>
+
+    <!-- // page image or divider -->
+    
+      
+    
+
+    <section id="page" role="main" data-content-field="main-content">
+
+      <!-- // CATEGORY NAV -->
+      
+
+      <div class="sqs-layout sqs-grid-12 columns-12" data-type="page" data-updated-on="1684872045879" id="page-508a094ee4b0f50834e1e3eb"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1606297820523_97549"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h1 style="text-align:center;white-space:pre-wrap;">URBAN DREAM BROKERAGE ACTIVATIONS</h1><p class="" style="white-space:pre-wrap;"><br>Nau mai harere mai… welcome to Urban Dream Brokerage Te Whanganui-a-Tara. UDB has previously assisted and brokered space for over 120 creative projects from 2013. The programme has encouraged the innovative use of vacant retail and public space to creatively build community. In partnership with Wellington City Council we have received a strong mandate to continue our mahi of enlivening our cities streets, strengthening the mauri of our city. </p><blockquote><p class="" style="white-space:pre-wrap;">Urban Dream Brokerage is providing a supportive platform for artistic expressions in physical space by connecting private partners to community-minded arts-focused organisations, they also weave an important network in the collective arts. Cultivating this community bolsters and uplifts the practitioners involved, ultimately enriching Te Whanganui a Tara's environment through creative practice. - Jack Gittings - Mouthfull Collective</p></blockquote><p class="" style="white-space:pre-wrap;">For inspiration view images and information on all previous projects we've assisted in Wellington here, and we look forward to sharing more with you over the coming time. UDB has previously worked in Dunedin, Masterton and Porirua, <a href="/othercities">view those projects here.</a></p>
+</div>
+
+
+
+</div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1680129541345_125748"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1270px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/party-of-treasures"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.69290924072266%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/7b448ba6-96b0-4aaf-a07b-f3dc33b27d80/ErikaGrantHero_11_Resize.jpg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/7b448ba6-96b0-4aaf-a07b-f3dc33b27d80/ErikaGrantHero_11_Resize.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/7b448ba6-96b0-4aaf-a07b-f3dc33b27d80/ErikaGrantHero_11_Resize.jpg" data-image-dimensions="1270x847" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="646d1b5f146b66093cc2c668" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1680129541345_956498"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/party-of-treasures">Project #79 LGWD Commission #4 Party of Rare &amp; Unearthly Treasures</a></h3><p class="" style="white-space:pre-wrap;">The community is invited to collaborate in public sewing workshops crafting costumes comprised of found and recycled materials. These outfits, in the theme of ‘Surrealism’ will be worn by a live band and the public for the grand finale of the project <a href="/party-of-treasures">‘Party of Rare &amp; Unearthly Treasures’.</a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1680129541345_154224"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1200px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/udbtv"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.66667175292969%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/ecc22502-8dc7-49d5-8e4b-f23c8e17a608/UDBTV_Banner_1.jpg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/ecc22502-8dc7-49d5-8e4b-f23c8e17a608/UDBTV_Banner_1.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/ecc22502-8dc7-49d5-8e4b-f23c8e17a608/UDBTV_Banner_1.jpg" data-image-dimensions="1200x800" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="6440ad3ac415cb48b188cf23" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1680129541345_643726"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/udbtv">PROJECT #78 LGWD COMMISSION #3 UDBTV Refuse to upgrade </a>                              </h3><p class="" style="white-space:pre-wrap;">Proudly brought to you in standard definition, Mike Heynes and Kedron Parker use their community video production facility, activating the UDB provocation of “Let’s Get Wellington Dreaming”. Property Partner: Ash Holwell, Spacelamp. More information <a href="/udbtv">here.</a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1678313670108_437411"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1270px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/soft-serve-social"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.69290924072266%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/13ef2cb3-7f4a-4983-86c8-f2b230092a7c/HeroImage-Night_May.jpg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/13ef2cb3-7f4a-4983-86c8-f2b230092a7c/HeroImage-Night_May.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/13ef2cb3-7f4a-4983-86c8-f2b230092a7c/HeroImage-Night_May.jpg" data-image-dimensions="1270x847" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="64507cfe97a308683aa7108a" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1680129541345_327922"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/soft-serve-social">PROJECT #77 LGWD COMMISSION #2 PLAYeSCAPE URBAN SWING SET</a>  </h3><p class="" style="white-space:pre-wrap;">Soft Serve Social Collective explore ways we can feel present, calm and connected when we are alone in public space at any time of day. A gentle swing for the city. Partners: LT McGuinness, Studio Pacific &amp; WCC. More information <a href="/soft-serve-social">here.</a></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1674005714529_586155"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1270px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/callwaiting"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.69290924072266%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/662c3142-8182-41fd-9465-e1556c7dacd8/OandP_Resize_1.JPG" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/662c3142-8182-41fd-9465-e1556c7dacd8/OandP_Resize_1.JPG" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/662c3142-8182-41fd-9465-e1556c7dacd8/OandP_Resize_1.JPG" data-image-dimensions="1270x847" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="6440aa7ba26f1c6b2e839a31" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1674005714529_632433"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/callwaiting">PROJECT #76 LGWD COMMISSION #1 CALL/WAITING</a></h3><p class="" style="white-space:pre-wrap;">Presented by O and P Works, an app based pick your narrative journey through Courtenay Place exploring the tensions of working life. Property partner: Readings Cinema, 106 Courtenay Pl. More information <a href="/callwaiting">here.</a></p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="70.63492063492063" data-block-type="5" id="block-yui_3_17_2_1_1650852918361_339280"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:3360px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/urban-dreams"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:70.63491821289062%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/e70620a6-1c95-430c-b25a-3bd147326f1d/Ollie+Hutton_Screenshot.png" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/e70620a6-1c95-430c-b25a-3bd147326f1d/Ollie+Hutton_Screenshot.png" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/e70620a6-1c95-430c-b25a-3bd147326f1d/Ollie+Hutton_Screenshot.png" data-image-dimensions="3360x2100" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="63746247c4a7e17b4dc69753" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1650852918361_298716"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/urban-dreams">PROJECT #73 urban dreams - te wāhi o te papa whakāta </a></h3><p class="" style="white-space:pre-wrap;">A public art moving image commission. Eight independent moving artworks screening across eight weeks of winter. Property partner: Readings Cinema, 106 Courtenay Place. More information <a href="/urban-dreams">here.</a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1674005714529_573733"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1270px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/santas-ai"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.69290924072266%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/f836d884-c172-470f-9556-911029aab8b6/santa2_Resize.jpg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/f836d884-c172-470f-9556-911029aab8b6/santa2_Resize.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/f836d884-c172-470f-9556-911029aab8b6/santa2_Resize.jpg" data-image-dimensions="1270x847" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="63c872ad81b92b2af8f63e8a" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1674005714529_621156"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/santas-ai">PROJECT #75 Santas little Artifical Intelligence workShop </a> </h3><p class="" style="white-space:pre-wrap;">German artist Clara Ehrenwerth with Goethe Institute opened an AI Xmas print making shop. Inviting people to create Xmas prints while reflecting on AI in relation to artmaking. Property partner: Readings Cinema, 106 Courtenay Place.</p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="70.37037037037037" data-block-type="5" id="block-yui_3_17_2_1_1650852918361_333115"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1200px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/inhabit"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:70.37036895751953%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/ab15aba0-a580-4553-bdf1-fd9c92626251/Inhabit.jpg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/ab15aba0-a580-4553-bdf1-fd9c92626251/Inhabit.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/ab15aba0-a580-4553-bdf1-fd9c92626251/Inhabit.jpg" data-image-dimensions="1200x800" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="63438ae615a71e54bce931f0" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1650852918361_278005"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/inhabit">PROJECT #72 COMMISSIONED WORK #6 Inhabit post partum</a></h3><p class="" style="white-space:pre-wrap;">Artist Holli McEntegart creates a space where we examine how community, cultural and whānau postpartum care has changed in Aotearoa. Property partner: Readings Cinema, 106 Courtenay Place. More information <a href="/inhabit">here.</a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1674005714529_561288"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1270px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/a-work-about-the-housing-crisis-with-an-indoor-outdoor-flow"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.69290924072266%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/0c847f17-5b85-494b-980c-ece56461fe81/HRC_1.jpg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/0c847f17-5b85-494b-980c-ece56461fe81/HRC_1.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/0c847f17-5b85-494b-980c-ece56461fe81/HRC_1.jpg" data-image-dimensions="1270x847" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="63c872d28ec28c3534179c44" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1674005714529_609792"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/a-work-about-the-housing-crisis-with-an-indoor-outdoor-flow">PROJECT #74 COMMISSIONED WORK #6 A work about the housing crisis with an indoor outdoor flow</a></h3><p class="" style="white-space:pre-wrap;">Artist Heleyni Pratley filmed and projected conversations with people of the current housing crisis. Property partner: Readings Cinema, 106 Courtenay Place. More information <a href="/a-work-about-the-housing-crisis-with-an-indoor-outdoor-flow">here.</a></p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="70.66895368782161" data-block-type="5" id="block-yui_3_17_2_1_1645386007263_91777"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1200px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/a-place-for-local-making"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:70.66895294189453%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/9af2bc06-493d-43cd-a947-cd61bdec0623/A_X_3.jpg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/9af2bc06-493d-43cd-a947-cd61bdec0623/A_X_3.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/9af2bc06-493d-43cd-a947-cd61bdec0623/A_X_3.jpg" data-image-dimensions="1200x800" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="626a1fad8ec65809d41caaa9" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1645386168339_92742"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/a-place-for-local-making">PROJECT #71 COMMISSIONED WORK #5 A PLACE FOR LOCAL MAKING</a></h3><p class="" style="white-space:pre-wrap;">Artists Xin Cheng and Adam Ben-Dror hosted a series of workshops, talks and reading groups through to May 2022. Property partner: Readings Cinema, 106 Courtenay Place. More information <a href="/a-place-for-local-making">here.</a></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="70.82228116710876" data-block-type="5" id="block-yui_3_17_2_1_1636752768836_188819"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/slp-taniwha"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:70.82228088378906%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/7fc4785c-75f0-42f1-8f4e-119ac477a6d8/SLP_3.JPG" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/7fc4785c-75f0-42f1-8f4e-119ac477a6d8/SLP_3.JPG" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/7fc4785c-75f0-42f1-8f4e-119ac477a6d8/SLP_3.JPG" data-image-dimensions="1500x1000" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="61d77f636cd3c1547f745774" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1636752768836_203807"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/slp-taniwha">PROJECT #70 Shared Lines: Pūtahitanga and Awakening The Taniwha</a></h3><p class="" style="white-space:pre-wrap;">Shared Lines Collective invite the public to new ways we are working together in light of the impact of Covid. Property Partner: Wellington City Council. More information <a href="/slp-taniwha">here.</a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="70.84048027444254" data-block-type="5" id="block-yui_3_17_2_1_1634179550281_105774"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:800px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/the-original-homeless"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:70.8404769897461%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/470f8276-295a-47d8-ad21-fd6caa7bc56f/TOH_1.jpg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/470f8276-295a-47d8-ad21-fd6caa7bc56f/TOH_1.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/470f8276-295a-47d8-ad21-fd6caa7bc56f/TOH_1.jpg" data-image-dimensions="800x1200" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="637462025b828c6ff9ffafba" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1606196502442_156264"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/the-original-homeless">project #69: commission #4: The Original homeless</a></h3><p class="" style="white-space:pre-wrap;">Bek Coogan pushed her response to the neo-liberal housing crisis in Aotearoa.   Property Partner: WCC 115 Manners Street. More information <a href="/the-original-homeless">here.</a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="70.15437392795883" data-block-type="5" id="block-yui_3_17_2_1_1624944551879_979597"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1200px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/rongoa"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:70.15437316894531%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/b53d8bdc-9962-4282-bae6-ddf678dc5383/H%C4%81kari_1.jpg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/b53d8bdc-9962-4282-bae6-ddf678dc5383/H%C4%81kari_1.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/b53d8bdc-9962-4282-bae6-ddf678dc5383/H%C4%81kari_1.jpg" data-image-dimensions="1200x800" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="61bafe9fab5931758e3cc34f" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1624944551879_1249706"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/rongoa" target="">Project #68: Commission #3 Rongoā-Marae-ROA-a rangi: He Moemoeā</a></h3><p class="" style="white-space:pre-wrap;">Tanya Ruka uses Rongoā Māori to acknowledge the wairua of inner city Te Whanganui-a-Tara. Property Partner: Readings Cinema. 106 Manners Street. More information <a href="/rongo">h</a><a href="/rongoa" target="">e</a><a href="/rongo">re.</a></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="71.08753315649867" data-block-type="5" id="block-yui_3_17_2_1_1632890269923_421934"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2499px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/face-your-waste"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:71.08753204345703%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1632894030228-TPHUFQEVYE27A3V7H4D8/P1000390.JPG" alt="P1000390.JPG" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1632894030228-TPHUFQEVYE27A3V7H4D8/P1000390.JPG" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1632894030228-TPHUFQEVYE27A3V7H4D8/P1000390.JPG" data-image-dimensions="2499x1875" data-image-focal-point="0.5,0.5" alt="P1000390.JPG" data-load="false" data-image-id="6153ef1cba23857662bb34f0" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1634184347436_689946"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/face-your-waste" target="">Project #66: face your waste</a></h3><p class="" style="white-space:pre-wrap;">International Food Waste Day project run by volunteers from NZ Food Waste Champions Group of Citizens. Property Partner: WCC Container - Corner of Willis St &amp; Bond St. More information <a href="/face-your-waste" target="">here.</a></p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1612495775619_218025"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1618px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="http://urbandreambrokerage.org.nz/city-theatre"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:75.0309066772461%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1614721795521-Q5R3OVKJNBFO8WEN4Q0X/CAT-Prophetic%2BVisions_7-image_Markuza%2BMaric.jpg" alt="CAT-Prophetic+Visions_7-image_Markuza+Maric.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1614721795521-Q5R3OVKJNBFO8WEN4Q0X/CAT-Prophetic%2BVisions_7-image_Markuza%2BMaric.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1614721795521-Q5R3OVKJNBFO8WEN4Q0X/CAT-Prophetic%2BVisions_7-image_Markuza%2BMaric.jpg" data-image-dimensions="1618x1214" data-image-focal-point="0.5,0.5" alt="CAT-Prophetic+Visions_7-image_Markuza+Maric.jpg" data-load="false" data-image-id="603eb30057922029ec8d8521" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1612495775619_202163"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="http://urbandreambrokerage.org.nz/city-theatre">WHAT IF THE CITY WAS A THEATRE?</a></h3><p class="" style="white-space:pre-wrap;">‘<a href="https://www.citytheatre.co.nz/">What If The City Was a Theatre?</a>' is a free, Wellington-wide programme that reimagines the limits of public space. More information <a href="/city-theatre" target="">here. </a>                     </p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="73.74631268436578" data-block-type="5" id="block-yui_3_17_2_1_1529888081702_88145"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:640px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/mouthfull-manifesto"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:73.7463150024414%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1532566479480-NOIWLQRK7WGJ9MTK8KF0/IMG_2846.JPG" alt="IMG_2846.JPG" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1532566479480-NOIWLQRK7WGJ9MTK8KF0/IMG_2846.JPG" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1532566479480-NOIWLQRK7WGJ9MTK8KF0/IMG_2846.JPG" data-image-dimensions="640x480" data-image-focal-point="0.5,0.5" alt="IMG_2846.JPG" data-load="false" data-image-id="5b591bce0e2e72dd68dedc8d" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1529888081702_158655"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/mouthfull-manifesto"><strong>PROJECT #61: MANIFESTO</strong></a></h3><p class="" style="white-space:pre-wrap;">Mouthfull Productions. Clyde Quay Wharf. June 2018 - ongoing. More information <a href="/mouthfull-manifesto">here</a>.</p>
+</div>
+
+
+
+</div></div><div class="sqs-block horizontalrule-block sqs-block-horizontalrule" data-block-type="47" id="block-yui_3_17_2_1_1613527758362_104565"><div class="sqs-block-content"><hr /></div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="70.37037037037037" data-block-type="5" id="block-yui_3_17_2_1_1624944551879_774268"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:3888px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/commonspace"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:70.37036895751953%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/bea07391-8789-4a7d-8959-e76461df4cd4/CS_Blog_1+websize.jpg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/bea07391-8789-4a7d-8959-e76461df4cd4/CS_Blog_1+websize.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/bea07391-8789-4a7d-8959-e76461df4cd4/CS_Blog_1+websize.jpg" data-image-dimensions="3888x2592" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="618ece4328151700f73923e9" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1624944551879_1233976"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/commonspace">Project #67: Commission #2 commonspace</a></h3><p class="" style="white-space:pre-wrap;">Mouthfull create a central place of being and belonging, learning and connecting. Property Partner: Ash Holwell. 113 Taranaki St. 21 July - 31 October 2021. More information <a href="/commonspace">here.</a></p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1614723844643_115985"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1626px;"
+        >
+          
+        
+        
+
+        
+          
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:75.03074645996094%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1614724108361-FZWIM610R3V73YA411X8/CAT%252B-%252BEchoes_1-image%25252BMarkuza%252BMaric.jpg" alt="CAT%2B-%2BEchoes_1-image%252BMarkuza%2BMaric.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1614724108361-FZWIM610R3V73YA411X8/CAT%252B-%252BEchoes_1-image%25252BMarkuza%252BMaric.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1614724108361-FZWIM610R3V73YA411X8/CAT%252B-%252BEchoes_1-image%25252BMarkuza%252BMaric.jpg" data-image-dimensions="1626x1220" data-image-focal-point="0.5,0.5" alt="CAT%2B-%2BEchoes_1-image%252BMarkuza%2BMaric.jpg" data-load="false" data-image-id="603ebc0aeef1f330f083c4a6" data-type="image" />
+                
+            </div>
+          </div>
+        
+          
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1613515707036_109759"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="http://urbandreambrokerage.org.nz/echoes-2021">Project #64: echoes</a></h3><p class="" style="white-space:pre-wrap;">Joe Dixon and Storybox. Property Partner: Willis Bond. 106a Cuba Street, Te Aro, Wellington. 5 - 28 February 2021. More information <a href="http://urbandreambrokerage.org.nz/echoes-2021">here.</a></p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1610514884074_317431"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1829px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="http://urbandreambrokerage.org.nz/101rants"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:74.95899200439453%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1611630868899-401QIBUVTVGCQYDP51QM/101%2BRants%2BHERO%2BImage.jpg" alt="101+Rants+HERO+Image.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1611630868899-401QIBUVTVGCQYDP51QM/101%2BRants%2BHERO%2BImage.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1611630868899-401QIBUVTVGCQYDP51QM/101%2BRants%2BHERO%2BImage.jpg" data-image-dimensions="1829x1371" data-image-focal-point="0.5,0.5" alt="101+Rants+HERO+Image.jpg" data-load="false" data-image-id="600f89134096c703223a5c42" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1610514884074_328541"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/101rants">PROJECT #62: 101 RANTS</a></h3><p class="" style="white-space:pre-wrap;">Marcus McShane. Property Partner: Michael Wall. 253 Wakefield Street. 13 - 28 January 2020. More information <a href="http://urbandreambrokerage.org.nz/101rants">here</a>.</p>
+</div>
+
+
+
+</div></div><div class="sqs-block horizontalrule-block sqs-block-horizontalrule" data-block-type="47" id="block-yui_3_17_2_1_1613527758362_110079"><div class="sqs-block-content"><hr /></div></div><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1526348632048_101403"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2423px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/crafted-voice"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:74.98968505859375%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1526350841949-NY75U8YTJZPVSNKX1ECO/Gentle+voice+6.jpg" alt="Gentle voice 6.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1526350841949-NY75U8YTJZPVSNKX1ECO/Gentle+voice+6.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1526350841949-NY75U8YTJZPVSNKX1ECO/Gentle+voice+6.jpg" data-image-dimensions="2423x1817" data-image-focal-point="0.5,0.5" alt="Gentle voice 6.jpg" data-load="false" data-image-id="5afa43eb575d1ff8cd9b10b7" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1526351500701_227945"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/crafted-voice"><strong>PROJECT #60: the CRAFTED VOICE</strong></a></h3><p class="" style="white-space:pre-wrap;">Rosie White. Wellington public library, hospital and district court. 19-21 June 21018. More information <a href="/crafted-voice">here</a>.</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="70.37037037037037" data-block-type="5" id="block-yui_3_17_2_1_1618181742214_294679"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1860px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="http://urbandreambrokerage.org.nz/electromagnetic-geographies"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:70.37036895751953%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1622948464299-181FGQHBI03INDHUTA50/EMG_Artists_1.jpg" alt="EMG_Artists_1.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1622948464299-181FGQHBI03INDHUTA50/EMG_Artists_1.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1622948464299-181FGQHBI03INDHUTA50/EMG_Artists_1.jpg" data-image-dimensions="1860x1240" data-image-focal-point="0.5,0.5" alt="EMG_Artists_1.jpg" data-load="false" data-image-id="60bc3a627e99d538c4c3a455" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1632890269923_610630"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/electromagnetic-geographies">Project #65 COMMISSION #1 ELECTROMAGNETIC GEOGRAPHIES</a></h3><p class="" style="white-space:pre-wrap;">Artist and critical engineer Julian Oliver and participating artists. Property Partner: Willis Bond. 106a Cuba St. 10-30 May 2021. More information <a href="http://urbandreambrokerage.org.nz/electromagnetic-geographies">here.</a></p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="73.01587301587301" data-block-type="5" id="block-yui_3_17_2_1_1612495775619_246180"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2189px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="http://urbandreambrokerage.org.nz/the-builders-fringe"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:73.01587677001953%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1622948668103-RDR3QUFBP11TN81TT5OY/TBF_1.jpg" alt="TBF_1.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1622948668103-RDR3QUFBP11TN81TT5OY/TBF_1.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1622948668103-RDR3QUFBP11TN81TT5OY/TBF_1.jpg" data-image-dimensions="2189x2240" data-image-focal-point="0.5,0.5" alt="TBF_1.jpg" data-load="false" data-image-id="60bc3b3027cb4f57a31f6fd3" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1612495775619_235633"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="http://urbandreambrokerage.org.nz/the-builders-fringe">PROJECT #63: THE BUILDERS’ FRINGE</a></h3><p class="" style="white-space:pre-wrap;">Maverick Creative. Property Partner: Willis Bond &amp; LT McGuinness. 161 Victoria St. 8-12 March 2021. More information <a href="http://urbandreambrokerage.org.nz/the-builders-fringe">here</a>.</p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1611630814198_280263"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2222px;"
+        >
+          
+        
+        
+
+        
+          
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:75.02249908447266%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1611638387528-8P8KNADZQ0TSOQO0G7I5/1%2BHERO%2BUBD%2B2.0%2B-%2BWEB%2B-%2BLAUNCH%2B17.12.2020%2B-%2BEbony%2BLamb%2BPhotographer-31.jpg" alt="1+HERO+UBD+2.0+-+WEB+-+LAUNCH+17.12.2020+-+Ebony+Lamb+Photographer-31.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1611638387528-8P8KNADZQ0TSOQO0G7I5/1%2BHERO%2BUBD%2B2.0%2B-%2BWEB%2B-%2BLAUNCH%2B17.12.2020%2B-%2BEbony%2BLamb%2BPhotographer-31.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1611638387528-8P8KNADZQ0TSOQO0G7I5/1%2BHERO%2BUBD%2B2.0%2B-%2BWEB%2B-%2BLAUNCH%2B17.12.2020%2B-%2BEbony%2BLamb%2BPhotographer-31.jpg" data-image-dimensions="2222x1667" data-image-focal-point="0.5,0.5" alt="1+HERO+UBD+2.0+-+WEB+-+LAUNCH+17.12.2020+-+Ebony+Lamb+Photographer-31.jpg" data-load="false" data-image-id="600fa66e9411b043404eae15" data-type="image" />
+                
+            </div>
+          </div>
+        
+          
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1611630814198_245144"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="http://urbandreambrokerage.org.nz/relaunchparty">UDB RELAUNCH celebration </a></h3><p class="" style="white-space:pre-wrap;">A celebratory launch of&nbsp;<a href="http://urbandreambrokerage.org.nz/book">Brokered&nbsp;Dreams: 98 Uses For Vacant Space</a> and the relaunch of&nbsp;Urban&nbsp;Dream&nbsp;Brokerage.</p>
+</div>
+
+
+
+</div></div><div class="sqs-block horizontalrule-block sqs-block-horizontalrule" data-block-type="47" id="block-yui_3_17_2_1_1613527758362_115460"><div class="sqs-block-content"><hr /></div></div><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="74.7148288973384" data-block-type="5" id="block-yui_3_17_2_1_1526348632048_85613"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1600px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/fragments"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:74.71482849121094%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1529879681623-JZG6JON53KMV72WAA919/Candace+Telephone+kiosk28.jpg" alt="Candace Telephone kiosk28.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1529879681623-JZG6JON53KMV72WAA919/Candace+Telephone+kiosk28.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1529879681623-JZG6JON53KMV72WAA919/Candace+Telephone+kiosk28.jpg" data-image-dimensions="1600x1068" data-image-focal-point="0.5,0.5" alt="Candace Telephone kiosk28.jpg" data-load="false" data-image-id="5b301c7503ce6498ad5851f0" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1610514884074_302879"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/fragments"><strong>PROJECT #59: FRAGMENTS</strong></a></h3><p class="" style="white-space:pre-wrap;">Candace Smith. Various public locations. 10-25 June 2018. More information <a href="/fragments">here</a>.</p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="55.75221238938053" data-block-type="5" id="block-yui_3_17_2_1_1522712968260_82263"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:800px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/the-lost-futures-exchange"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:55.75221252441406%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1528789351689-88C3ORSQH7DP4R8W79YP/14-36-08_30-05-18.jpg" alt="14-36-08_30-05-18.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1528789351689-88C3ORSQH7DP4R8W79YP/14-36-08_30-05-18.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1528789351689-88C3ORSQH7DP4R8W79YP/14-36-08_30-05-18.jpg" data-image-dimensions="800x534" data-image-focal-point="0.5,0.5" alt="14-36-08_30-05-18.jpg" data-load="false" data-image-id="5b1f7967758d460b34db850a" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1522712968260_238870"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/the-lost-futures-exchange"><strong>Project #58: The Lost Futures Exchange</strong></a></h3><p class="" style="white-space:pre-wrap;">Mark Antony Smith. Property Partner:&nbsp;Bizdojo.&nbsp;3 Market Lane. 6 April - 30 May 2018, Thursdays 1pm-5pm. More information <a href="/the-lost-futures-exchange">here</a>.</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="56.932153392330385" data-block-type="5" id="block-yui_3_17_2_1_1522712968260_93895"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1024px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/new-page-2"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:56.932151794433594%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1530486980709-54X816EUCW14DDND60BS/imagejpeg_1.jpg" alt="imagejpeg_1.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1530486980709-54X816EUCW14DDND60BS/imagejpeg_1.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1530486980709-54X816EUCW14DDND60BS/imagejpeg_1.jpg" data-image-dimensions="1024x768" data-image-focal-point="0.5,0.5" alt="imagejpeg_1.jpg" data-load="false" data-image-id="5b3960c4562fa78787cb6480" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1522712968260_242868"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/new-page-2" target="_blank"><strong>2018 Peer to Peer Mentorship Programme</strong></a></h3><p class="" style="white-space:pre-wrap;">Rosie White with Jo Randerson, Mark Antony Smith with Leo-Gene Peters, Candace Smith with Vivien Atkinson, and Mouthfull with Sam Trubridge. More information <a href="/new-page-2">here</a>.</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="56.342182890855455" data-block-type="5" id="block-yui_3_17_2_1_1523330494548_84820"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1000px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/urban-dreams-podcast"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:56.34218215942383%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1523330618769-RCAIFD4M9J74MXJLCQO5/_AA97620.jpg" alt="_AA97620.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1523330618769-RCAIFD4M9J74MXJLCQO5/_AA97620.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1523330618769-RCAIFD4M9J74MXJLCQO5/_AA97620.jpg" data-image-dimensions="1000x667" data-image-focal-point="0.5,0.5" alt="_AA97620.jpg" data-load="false" data-image-id="5acc2e318a922dc77306358f" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1523330494548_220229"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/urban-dreams-podcast"><strong>&nbsp;2017-2018 urban dreams conversation AND PODCAST</strong></a></h3><p class="" style="white-space:pre-wrap;">More information <a href="/urban-dreams-podcast">here</a>.</p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="67.15976331360946" data-block-type="5" id="block-yui_3_17_2_3_1509495580161_67673"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/performance-art-week-aotearoa"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:67.15975952148438%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1510780067950-CK31ZNT8G98SF0GQNVVP/IMG_0868.jpg" alt="IMG_0868.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1510780067950-CK31ZNT8G98SF0GQNVVP/IMG_0868.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1510780067950-CK31ZNT8G98SF0GQNVVP/IMG_0868.jpg" data-image-dimensions="2500x1875" data-image-focal-point="0.5,0.5" alt="IMG_0868.jpg" data-load="false" data-image-id="5a0cac77652dea776ad8b340" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_3_1509495580161_101701"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/performance-art-week-aotearoa"><strong>PROJECT #57: PERFORMANCE ART WEEK AOTEAROA</strong> </a></h3><p class="" style="white-space:pre-wrap;">8-12 November 2017. 17 Tory Street and Play_Station. More information <a href="/performance-art-week-aotearoa">here</a>.</p><p class="" style="white-space:pre-wrap;">&nbsp;</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_5_1505177060938_78516"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/shared-lines"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.68000030517578%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1508985491221-UX3RUGGVDMTMLWZF2FC2/UBD+-+Shared+lines+Colour+-+low+res+-+Ebony+Lamb+10.17-3.jpg" alt="UBD - Shared lines Colour - low res - Ebony Lamb 10.17-3.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1508985491221-UX3RUGGVDMTMLWZF2FC2/UBD+-+Shared+lines+Colour+-+low+res+-+Ebony+Lamb+10.17-3.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1508985491221-UX3RUGGVDMTMLWZF2FC2/UBD+-+Shared+lines+Colour+-+low+res+-+Ebony+Lamb+10.17-3.jpg" data-image-dimensions="2500x1667" data-image-focal-point="0.5,0.5" alt="UBD - Shared lines Colour - low res - Ebony Lamb 10.17-3.jpg" data-load="false" data-image-id="59f14a8d90bcce5ece01afaf" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_3_1505178903510_135172"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/shared-lines"><strong>PROJECT #56: SHARED LINES: WELLINGTON</strong></a></h3><p class="" style="white-space:pre-wrap;">Property partner: Willis Bond. Waterfront, Adam Auditorium City Gallery, Thistle Hall Gallery 17-21 October 2017. More information <a href="/shared-lines">here</a>.<br>&nbsp;</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_9_1505177060938_223591"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:800px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/retail-cabaret"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.75%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1505879060692-1F3HTGZKKTDKY8UVTVWZ/19-47-29_18-09-17.jpg" alt="19-47-29_18-09-17.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1505879060692-1F3HTGZKKTDKY8UVTVWZ/19-47-29_18-09-17.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1505879060692-1F3HTGZKKTDKY8UVTVWZ/19-47-29_18-09-17.jpg" data-image-dimensions="800x534" data-image-focal-point="0.5,0.5" alt="19-47-29_18-09-17.jpg" data-load="false" data-image-id="59c1e41329f1870809c01a14" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_3_1505178903510_84102"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/retail-cabaret"><strong>PROJECT #55: RETAIL CABARET</strong></a></h3><p class="" style="white-space:pre-wrap;">Property partner: Scruffy Bunny. Readings Cinemas Courtenay Central. 19 – 22 September 2017 8pm, 23 September 3pm. More information <a href="/retail-cabaret">here</a>.</p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_3_1504051298492_77275"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/political-cutz-2017"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.68000030517578%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1504598796659-ZKOZ6LK7KBUKVQJJBPMM/UDB+-+POL+CUTZ++web+res+-+E.Lamb+2017-115.jpg" alt="UDB - POL CUTZ  web res - E.Lamb 2017-115.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1504598796659-ZKOZ6LK7KBUKVQJJBPMM/UDB+-+POL+CUTZ++web+res+-+E.Lamb+2017-115.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1504598796659-ZKOZ6LK7KBUKVQJJBPMM/UDB+-+POL+CUTZ++web+res+-+E.Lamb+2017-115.jpg" data-image-dimensions="2500x1667" data-image-focal-point="0.5,0.5" alt="UDB - POL CUTZ  web res - E.Lamb 2017-115.jpg" data-load="false" data-image-id="59ae5b06b8a79b5194ccf121" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_9_1504051298492_91270"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/political-cutz-2017"><strong>PROJECT #54: POLITICAL CUTZ 2017</strong></a></h3><p class="" style="white-space:pre-wrap;">Barbarian Productions/Maverick Creative. Property: Maurice and Kaye Clarke. Public Trust Building, 131 Lambton Quay. 5-9 September 2017, 10am-4pm (Thurs until 6pm). More information <a href="/political-cutz-2017">here</a>.</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="66.41221374045801" data-block-type="5" id="block-yui_3_17_2_3_1498795888546_78222"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/project-fashion"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.41221618652344%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1501213185141-TU457MWRP9751XBRS1H8/UDB+Public+Trust+colour-+July+17+-+E.Lamb+Photography-26.jpg" alt="UDB Public Trust colour- July 17 - E.Lamb Photography-26.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1501213185141-TU457MWRP9751XBRS1H8/UDB+Public+Trust+colour-+July+17+-+E.Lamb+Photography-26.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1501213185141-TU457MWRP9751XBRS1H8/UDB+Public+Trust+colour-+July+17+-+E.Lamb+Photography-26.jpg" data-image-dimensions="2500x1667" data-image-focal-point="0.5,0.5" alt="UDB Public Trust colour- July 17 - E.Lamb Photography-26.jpg" data-load="false" data-image-id="597ab1fc3e00be4519178810" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_3_1498795888546_95162"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/project-fashion"><strong>PROJECT #53: PROJECT FASHION</strong></a></h3><p class="" style="white-space:pre-wrap;">The Display Space. Property: Maurice and Kaye Clarke. Public Trust Building, 131 Lambton Quay. 13-31 July 2017. Tues-Sat 10am-6pm. More information <a href="/project-fashion">here</a>.</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_6_1493944269061_74533"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2000px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/unsettled"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.75%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1496719132033-6J28NRPHYAVEAGKZWT1P/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1496719132033-6J28NRPHYAVEAGKZWT1P/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1496719132033-6J28NRPHYAVEAGKZWT1P/image-asset.jpeg" data-image-dimensions="2000x1335" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="59361f149de4bbb02330621a" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_3_1498795888546_238459"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/unsettled"><strong>PROJECT #52: unsettled</strong></a></h3><p class="" style="white-space:pre-wrap;">Rana Haddad and Pascal Hachem. Property partner: Zebrano. 2 Tory Street. May 3 – 16 2017. More information <a href="/unsettled">here.</a></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_3_1492990944624_76752"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:525px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/the-song-dispensary"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.66667175292969%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1492991009257-9D3I173R35CVTDQG8APG/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1492991009257-9D3I173R35CVTDQG8APG/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1492991009257-9D3I173R35CVTDQG8APG/image-asset.jpeg" data-image-dimensions="525x350" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="58fd3c20ff7c502a493da6d7" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_3_1492990944624_153472"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/the-song-dispensary"><strong>Project #51: The Song Dispensary</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Hans Kellett and Dan Untitled. Property partner: Zebrano. 2 Tory Street. April 26 – 30, 2017. More information </strong><a href="/the-song-dispensary"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="66.6030534351145" data-block-type="5" id="block-yui_3_17_2_3_1487724286954_68190"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/fouvale-imperium"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.6030502319336%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1488429211691-J3YV6V7SXFUZHQWZ6HPC/UDB+-+E.Lamb+23.02.17+Low+res+-+Colour+-16.jpg" alt="UDB - E.Lamb 23.02.17 Low res - Colour -16.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1488429211691-J3YV6V7SXFUZHQWZ6HPC/UDB+-+E.Lamb+23.02.17+Low+res+-+Colour+-16.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1488429211691-J3YV6V7SXFUZHQWZ6HPC/UDB+-+E.Lamb+23.02.17+Low+res+-+Colour+-16.jpg" data-image-dimensions="2500x1667" data-image-focal-point="0.5,0.5" alt="UDB - E.Lamb 23.02.17 Low res - Colour -16.jpg" data-load="false" data-image-id="58b7a095bf629a0675924935" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_6_1487721825235_70644"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/fouvale-imperium"><strong>PROJECT #50: FOUVALE IMPERIUM</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>James Nokise. Clyde Quay Wharf. Property partner: Wellington City Council. 21 - 25 February 2017. More information </strong><a href="/fouvale-imperium"><strong>here</strong></a><strong>.</strong></p><p class="" style="white-space:pre-wrap;">&nbsp;</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="66.22137404580153" data-block-type="5" id="block-yui_3_17_2_6_1485817758538_64552"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/tapes"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.22137451171875%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1489111036982-T8ILO72MC496B32VJMGK/IMG_7349.jpg" alt="IMG_7349.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1489111036982-T8ILO72MC496B32VJMGK/IMG_7349.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1489111036982-T8ILO72MC496B32VJMGK/IMG_7349.jpg" data-image-dimensions="2500x1667" data-image-focal-point="0.5,0.5" alt="IMG_7349.jpg" data-load="false" data-image-id="58c207f46a4963a1d42df1ed" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_6_1485817758538_155741"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/tapes"><strong>PROJECT #49 THE BASEMENT TAPES</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Stella Reid. Property partner: Wellington City Council. 10 -13 February 2017. Clyde Quay Wharf. More information </strong><a href="/tapes"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_3_1478554626360_63589"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2000px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/galathea-into-the-bush"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.75%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1480015962644-T1KKAEBQXF09WOBGZ2E7/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1480015962644-T1KKAEBQXF09WOBGZ2E7/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1480015962644-T1KKAEBQXF09WOBGZ2E7/image-asset.jpeg" data-image-dimensions="2000x1335" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="58374059414fb5a61506875c" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_3_1478554626360_75747"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/galathea-into-the-bush"><strong>PROJECT #48: GALATHEA INTO THE BUSH</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Twin City Productions. Property partners: Maurice and Kaye Clark. Public Trust Building, 131 Lambton Quay. 23 November - 3 December 2016. More information </strong><a href="/galathea-into-the-bush"><strong>here</strong></a><strong>.</strong></p><p class="" style="white-space:pre-wrap;">&nbsp;</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_7_1474408287193_66896"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2000px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/glade"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.75%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1477011634560-S7Z7MMK9HQFFUFE6R4PR/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1477011634560-S7Z7MMK9HQFFUFE6R4PR/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1477011634560-S7Z7MMK9HQFFUFE6R4PR/image-asset.jpeg" data-image-dimensions="2000x1335" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="580968b0d482e9896765ce07" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_7_1474408287193_74840"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/glade"><strong>PROJECT #47: GLADE</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Lux. Property partner: Wellington City Council. 6/22 Herd Street (meeting place). 30 September - 9 October. 12pm-8pm. More information </strong><a href="/glade"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_8_1475018225469_79388"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/cyber-nectar"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.68000030517578%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1475019169432-SXK3U3GZT6K5K0SQJAE4/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1475019169432-SXK3U3GZT6K5K0SQJAE4/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1475019169432-SXK3U3GZT6K5K0SQJAE4/image-asset.jpeg" data-image-dimensions="2500x1667" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="57eb019446c3c474982f99b3" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_8_1475018225469_108483"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/cyber-nectar"><strong>PROJECT #46: CYBER NECTAR</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Lokal Stories. Properties: various. 28 September - 14 October. More information </strong><a href="/cyber-nectar"><strong>here</strong></a><strong>.</strong></p><p class="" style="white-space:pre-wrap;">&nbsp;</p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="56.91823899371069" data-block-type="5" id="block-yui_3_17_2_6_1469052940196_70578"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:495px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/coliberate"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:56.91823959350586%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1469053482056-CQY5LIL0EURW4ECVYDP8/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1469053482056-CQY5LIL0EURW4ECVYDP8/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1469053482056-CQY5LIL0EURW4ECVYDP8/image-asset.jpeg" data-image-dimensions="495x384" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="578ff9694402434ae8dad9ae" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_3_1470197610120_414169"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/coliberate"><strong>PROJECT #45: CO-LIBERATE</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Property Partner: Mt Iron Investments Ltd. Level 2, 111 Customhouse Quay. 31st July, 2016 - ongoing. More information </strong><a href="/coliberate"><strong>here</strong></a><strong>.</strong></p><p class="" style="white-space:pre-wrap;">&nbsp;</p><p class="" style="white-space:pre-wrap;">&nbsp;</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="56.91823899371069" data-block-type="5" id="block-yui_3_17_2_7_1468898886075_72126"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:3456px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/unseasonal-change"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:56.91823959350586%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1470276005759-V8CVYDPRC3EBJKRERPU8/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1470276005759-V8CVYDPRC3EBJKRERPU8/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1470276005759-V8CVYDPRC3EBJKRERPU8/image-asset.jpeg" data-image-dimensions="3456x2304" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="57a2a19946c3c4ef06cce4cc" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_3_1470197610120_344591"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/unseasonal-change"><strong>PROJECT #44: UNSEASONAL CHANGE</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Andrea Selwood. Property Partner: Wellington City Council. 1 Clyde Quay Wharf.&nbsp;July 20th -August 20th&nbsp;2016. More information </strong><a href="/unseasonal-change"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_3_1465946672170_60614"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:650px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/bike-laboratory-2016"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:56.153846740722656%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1466468675139-X9YEER30STBS053DSK2O/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1466468675139-X9YEER30STBS053DSK2O/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1466468675139-X9YEER30STBS053DSK2O/image-asset.jpeg" data-image-dimensions="650x365" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="5768891646c3c4f6756fb83c" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_7_1465947015038_63910"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/bike-laboratory-2016"><strong>PROJECT #43:&nbsp;Lucid Dreambike laboratory</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Property Partner: Wellington City Council. 1 Clyde Quay Wharf.&nbsp;17th June - 17th July 2016. More information </strong><a href="/bike-laboratory-2016"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="56.582633053221286" data-block-type="5" id="block-yui_3_17_2_3_1457401952118_59351"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2246px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/lightning-lab-xx"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:56.58263397216797%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1457402054666-TM65HO4Z5FGU10O6WNE8/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1457402054666-TM65HO4Z5FGU10O6WNE8/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1457402054666-TM65HO4Z5FGU10O6WNE8/image-asset.jpeg" data-image-dimensions="2246x1070" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="56de30c0d51cd41a9a3550af" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_12_1456181556899_150189"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/lightning-lab-xx"><strong>PROJECT #42:&nbsp;LIGHTNING LAB XX</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Level 1, 7 Dixon St.&nbsp;From 1st March 2016. More information </strong><a href="/lightning-lab-xx"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="56.582633053221286" data-block-type="5" id="block-yui_3_17_2_12_1456181556899_157903"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:640px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/idlenesslabouritory"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:56.58263397216797%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1459912377514-4LJPOVEDYT9H7HQ8NTHJ/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1459912377514-4LJPOVEDYT9H7HQ8NTHJ/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1459912377514-4LJPOVEDYT9H7HQ8NTHJ/image-asset.jpeg" data-image-dimensions="640x480" data-image-focal-point="0.5,0.5923076923076923" alt="" data-load="false" data-image-id="57047eb7e321408a6313a25e" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_2_1448923585618_67043"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/idlenesslabouritory"><strong>PROJECT #41: IDLENESS LABORATORY</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Property Partner: Cook Strait Properties. 1 Marjoribanks Street. 8-9 March 2016.&nbsp;More info </strong><a href="/idlenesslabouritory"><strong>here.</strong></a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="56.5359477124183" data-block-type="5" id="block-yui_3_17_2_3_1455762008844_55757"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1000px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/scratch-nacht"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:56.535945892333984%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1455762823299-99KA7MVZBMRMLQ36Z0CQ/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1455762823299-99KA7MVZBMRMLQ36Z0CQ/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1455762823299-99KA7MVZBMRMLQ36Z0CQ/image-asset.jpeg" data-image-dimensions="1000x1000" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="56c52d6a2e83f8adcf3a3a4e" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_3_1455762008844_516548"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/scratch-nacht"><strong>PROJECT #40: SCRATCH NACHT</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Property Partner: Wellington City Council. 1 Clyde Quay Wharf. 22-29 February 2016. More information </strong><a href="/scratch-nacht"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="61.834319526627226" data-block-type="5" id="block-yui_3_17_2_3_1455762008844_597797"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2000px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/groeni-x-joel-fear"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:61.834320068359375%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1456182120241-EQTS5N4WFTBZWYZSNX3O/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1456182120241-EQTS5N4WFTBZWYZSNX3O/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1456182120241-EQTS5N4WFTBZWYZSNX3O/image-asset.jpeg" data-image-dimensions="2000x1335" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="56cb935ae707ebc39cedb756" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_6_1465255983598_395155"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/groeni-x-joel-fear"><strong>PROJECT #39: GROENI X JOEL FEAR</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Property Partner: Horsfall Properties. 88 Riddiford Street. From 17 February 2016. More information </strong><a href="/groeni-x-joel-fear"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="61.53846153846154" data-block-type="5" id="block-yui_3_17_2_2_1448921922403_349716"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2048px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/hawaii-cultural-centre"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:61.53845977783203%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1449538353024-WWOA5ZR5J0KV93DPWCL0/IMG_0089.JPG" alt="IMG_0089.JPG" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1449538353024-WWOA5ZR5J0KV93DPWCL0/IMG_0089.JPG" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1449538353024-WWOA5ZR5J0KV93DPWCL0/IMG_0089.JPG" data-image-dimensions="2048x1365" data-image-focal-point="0.5,0.5" alt="IMG_0089.JPG" data-load="false" data-image-id="5666332ca976afddc7096ef3" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_6_1465255983598_411027"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/hawaii-cultural-centre"><strong>PROJECT #38: HAWAI'I CULTURE CENTRE</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Property Partner: Prime Property. 20 Ballance Street. From 1st December 2015. More information </strong><a href="/hawaii-cultural-centre"><strong>here</strong></a><strong>.&nbsp;</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="61.0079575596817" data-block-type="5" id="block-yui_3_17_2_2_1448920263980_69139"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:5184px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/performance-lab-2015"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:61.007957458496094%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1449530995087-P37CRQ6XQR0MY4EK663I/26%2Bcolour-2.jpg" alt="26+colour-2.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1449530995087-P37CRQ6XQR0MY4EK663I/26%2Bcolour-2.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1449530995087-P37CRQ6XQR0MY4EK663I/26%2Bcolour-2.jpg" data-image-dimensions="5184x3456" data-image-focal-point="0.5,0.5526315789473685" alt="26+colour-2.jpg" data-load="false" data-image-id="56661649d8af105622ced5e5" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_6_1465255983598_476082"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="http://urbandreambrokerage.org.nz/performance-lab-2015"><strong>PROJECT #37: PERFORMANCE LAB</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Property Partner: Cook Strait Properties Ltd.&nbsp;1 Marjoribanks Street. 1 Dec 2015 - 11 Mar 2016. More information </strong><a href="http://urbandreambrokerage.org.nz/performance-lab-2015"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="61.24260355029586" data-block-type="5" id="block-yui_3_17_2_2_1433464947697_46542"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:800px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/sub-urban"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:61.24260330200195%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1439900988285-DJ4KML0LYWYUEUSD6YSX/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1439900988285-DJ4KML0LYWYUEUSD6YSX/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1439900988285-DJ4KML0LYWYUEUSD6YSX/image-asset.jpeg" data-image-dimensions="800x534" data-image-focal-point="0.5,1.0" alt="" data-load="false" data-image-id="55d3253ae4b075ba970771cb" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_6_1465255983598_201794"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/sub-urban"><strong>PROJECT #36:&nbsp;SUB URBAN CO-WORKING</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Property Partner: DNZ Property Fund Ltd. Johnsonville Shopping Centre. From 2 June 2015. More information </strong><a href="/sub-urban"><strong>here</strong></a><strong>.&nbsp;</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="60.47745358090185" data-block-type="5" id="block-yui_3_17_2_2_1433378292820_45592"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/wheel-of-justice"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:60.477455139160156%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1433378383266-L4VP76GCBDZTTQ09DO5P/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1433378383266-L4VP76GCBDZTTQ09DO5P/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1433378383266-L4VP76GCBDZTTQ09DO5P/image-asset.jpeg" data-image-dimensions="2500x1406" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="556f9e3de4b0b2df44546d8d" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_12_1456181556899_102027"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/wheel-of-justice"><strong>PROJECT #35: WHEEL OF JUSTICE</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Amnesty International New Zealand. Property Partner: Vicinity Ltd. 307 Willis Street, Wellington. 6 -7 June 2015. More information </strong><a href="/wheel-of-justice"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="60.946745562130175" data-block-type="5" id="block-yui_3_17_2_6_1431666384731_94119"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:800px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/surveillance-awareness-laboratory"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:60.946746826171875%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1432854777887-8HD5DFRGT0MYT1IBJGC5/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1432854777887-8HD5DFRGT0MYT1IBJGC5/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1432854777887-8HD5DFRGT0MYT1IBJGC5/image-asset.jpeg" data-image-dimensions="800x534" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="5567a0f8e4b07df22a1a5e00" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_6_1465255983598_309838"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/surveillance-awareness-laboratory"><strong>PROJECT #34: SURVEILLANCE AWARENESS BUREAU</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Modelab. Property partner: DNZ Property Ltd. 1 Grey Street. 27 May – 13 June. Wednesday–Friday 12–5pm, Saturday 12–3pm.&nbsp;More information </strong><a href="/surveillance-awareness-laboratory"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_2_1427415416694_66834"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:800px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/new-gallery-1"
+              target="_blank"
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.75%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1428451100855-CMAKX73JU02ZFPSN8T6P/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1428451100855-CMAKX73JU02ZFPSN8T6P/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1428451100855-CMAKX73JU02ZFPSN8T6P/image-asset.jpeg" data-image-dimensions="800x534" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="55246f1ae4b0fed3b8c51fc5" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_2_1427415416694_48440"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/new-gallery-1"><strong>Project #33: Laou </strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Nelio and Duncan Passmore. Property partner: Nidus Properties. Cnr Torrens and Webb Street. 28 March - 4 April 2015. More information </strong><a href="/new-gallery-1"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_7_1423789523782_40352"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1280px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/the-wet-index"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.71875%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1424817109534-8UMQ44E9LFUUJTBKX990/2R7A6255.jpeg" alt="2R7A6255.jpeg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1424817109534-8UMQ44E9LFUUJTBKX990/2R7A6255.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1424817109534-8UMQ44E9LFUUJTBKX990/2R7A6255.jpeg" data-image-dimensions="1280x854" data-image-focal-point="0.5,0.5" alt="2R7A6255.jpeg" data-load="false" data-image-id="54ecfbd3e4b0dc5d50456b50" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_7_1423789523782_53238"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/the-wet-index"><strong>PROJECT #32: THE WET INDEX</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Kedron Parker and Bruce McNaught. Property partner: Cornerstone Properties. 11 Woodward Street. From 16 February 2015. More information </strong><a href="/the-wet-index"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="66.79389312977099" data-block-type="5" id="block-yui_3_17_2_2_1421783472039_94263"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:960px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/performance-lab"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.79389190673828%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1423791370924-2RUST3Y5VIJCTJDBAQ4O/5photo.JPG" alt="5photo.JPG" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1423791370924-2RUST3Y5VIJCTJDBAQ4O/5photo.JPG" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1423791370924-2RUST3Y5VIJCTJDBAQ4O/5photo.JPG" data-image-dimensions="960x720" data-image-focal-point="0.5,0.5" alt="5photo.JPG" data-load="false" data-image-id="54dd5508e4b02586720e9bda" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_2_1421783472039_49372"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/performance-lab"><strong>PROJECT #31: PERFORMANCE LAB&nbsp;2014</strong></a></h3><p class="" style="white-space:pre-wrap;"><strong>Performance Arcade. Property partner: Prime Property. 17 Whitmore Street. 22 December - 28 February 2015. More information </strong><a href="/performance-lab"><strong>here</strong></a><strong>. </strong></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="61.94690265486725" data-block-type="5" id="block-yui_3_17_2_7_1418763971386_44224"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/flow-chart"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:61.946903228759766%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1421980348591-E7D1R2LAU6VW5CHMEADW/P1030091.JPG" alt="P1030091.JPG" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1421980348591-E7D1R2LAU6VW5CHMEADW/P1030091.JPG" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1421980348591-E7D1R2LAU6VW5CHMEADW/P1030091.JPG" data-image-dimensions="2500x1405" data-image-focal-point="0.5,0.5" alt="P1030091.JPG" data-load="false" data-image-id="54c1b2b5e4b07b213a4687aa" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_7_1418763971386_152575"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/flow-chart">PROJECT #30: FLOW CHART</a></h3><p class="" style="white-space:pre-wrap;"><strong>Andrea Selwood. Property partner: Prime Property. Greenock House, 108 Lambton Quay. 24 December - 25 January 2015. More information </strong><a href="https://urbandreambrokerage.squarespace.com/flow-chart"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="61.834319526627226" data-block-type="5" id="block-yui_3_17_2_2_1418255333542_36968"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:640px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/the-colourists"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:61.834320068359375%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1418897401144-F4C3R7566J9JKN5D6AIZ/image.jpg" alt="image.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1418897401144-F4C3R7566J9JKN5D6AIZ/image.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1418897401144-F4C3R7566J9JKN5D6AIZ/image.jpg" data-image-dimensions="640x480" data-image-focal-point="0.5,0.5" alt="image.jpg" data-load="false" data-image-id="5492a7f9e4b07719aacc0125" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_2_1418255333542_48396"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="#">Project #29: The Colourists</a></h3><p class="" style="white-space:pre-wrap;"><strong>Sophia McKinnon. Property partner: Prime Property. Greenock House, 108 Lambton Quay</strong>.<strong> 15 - 20 December 2014. More information </strong><a href="/the-colourists"><strong>here</strong></a><strong>.&nbsp; </strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="61.834319526627226" data-block-type="5" id="block-yui_3_17_2_1_1417479520578_77045"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:800px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/concoction"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:61.834320068359375%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1418075758049-4QO22F4B74YFPWTDXKCH/Elbowroom_Concoction+Image.jpg" alt="Elbowroom_Concoction Image.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1418075758049-4QO22F4B74YFPWTDXKCH/Elbowroom_Concoction+Image.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1418075758049-4QO22F4B74YFPWTDXKCH/Elbowroom_Concoction+Image.jpg" data-image-dimensions="800x534" data-image-focal-point="0.5,0.5" alt="Elbowroom_Concoction Image.jpg" data-load="false" data-image-id="54861e6ee4b051cf8a8abb62" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_2_1418255333542_149708"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/concoction">Project #28: Concoction </a></h3><p class="" style="white-space:pre-wrap;"><strong>Elbowroom - The Moving Gallery. Property partner: Prime Property. 17 Whitmore Street. 7 - 14 December. More information </strong><a href="/concoction"><strong>here</strong></a><strong>. </strong></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="64.54545454545455" data-block-type="5" id="block-yui_3_17_2_1_1417592124246_86739"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:800px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/puta"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:64.54545593261719%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1425328225582-XLDRLJM7TRNE95BZUZ6E/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1425328225582-XLDRLJM7TRNE95BZUZ6E/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1425328225582-XLDRLJM7TRNE95BZUZ6E/image-asset.jpeg" data-image-dimensions="800x534" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="54f4c85fe4b08c831d3d93a0" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1417592124246_115053"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="#">Project #27: Puta</a></h3><p class="" style="white-space:pre-wrap;"><strong>Boys and Girls Institute. Chaffers Dock, 1 Herd Street. December 1 2014 – ongoing. Monday-Friday, 9-5pm.&nbsp; More information </strong><a href="/puta"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1413764194787_50285"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/free-yoga-day"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:64.12000274658203%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1413765639068-9SHTMC463ZW6THNT2XBB/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1413765639068-9SHTMC463ZW6THNT2XBB/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1413765639068-9SHTMC463ZW6THNT2XBB/image-asset.jpeg" data-image-dimensions="2500x1603" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="54445a07e4b0e6f12d4f832d" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1413764194787_59852"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/free-yoga-day">Project #26: Free Yoga Day</a></h3><p class="" style="white-space:pre-wrap;"><strong>Property Partner DNZ Property Ltd. 1 Grey Street. Labour Day, 27 October 2014. 7:30am - 9:30pm. For more information </strong><a href="http://freeyogaday.wix.com/wellington2014" target="_blank"><strong>go here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="64.30678466076697" data-block-type="5" id="block-yui_3_17_2_1_1412279815796_98931"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:800px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/homies-cosy-teahouse"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:64.3067855834961%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1418081137757-ZAZ14M9LKNYRUN29OT05/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1418081137757-ZAZ14M9LKNYRUN29OT05/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1418081137757-ZAZ14M9LKNYRUN29OT05/image-asset.jpeg" data-image-dimensions="800x534" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="54863371e4b033b4dc30e3b2" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1412279815796_287158"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="#">Project #25: Homies Cosy Teahouse&nbsp;</a></h3><p class="" style="white-space:pre-wrap;"><strong>Naomi Smith. Property Partner: Standard 806 Ltd. 90 Manners Street. From 6 October 2014. 10am - midnight, seven days. For more information go </strong><a href="/homies-cosy-teahouse"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1412279815796_300456"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:100%;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/vaudevillains-clubhouse"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.66667175292969%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1414094780526-RHW24IK55LNBV4C8U3RZ/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1414094780526-RHW24IK55LNBV4C8U3RZ/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1414094780526-RHW24IK55LNBV4C8U3RZ/image-asset.jpeg" data-image-dimensions="960x640" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="54495fbce4b06cde44f35d88" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1411004466496_39927"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:800px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/aura-secure"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.75%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1412137686093-NJ0TETZ5WE075JFDSWWY/AuraSecure-brochure+front.jpg" alt="AuraSecure-brochure front.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1412137686093-NJ0TETZ5WE075JFDSWWY/AuraSecure-brochure+front.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1412137686093-NJ0TETZ5WE075JFDSWWY/AuraSecure-brochure+front.jpg" data-image-dimensions="800x534" data-image-focal-point="0.5,0.5" alt="AuraSecure-brochure front.jpg" data-load="false" data-image-id="542b82d6e4b00f635c614579" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1411004466496_77520"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:100%;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/dirty-laundry"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.75%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1412136478357-LAPVXXOGDE9NPJY8NS9S/10616508_813110688711144_8646842810416095295_n.jpg" alt="10616508_813110688711144_8646842810416095295_n.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1412136478357-LAPVXXOGDE9NPJY8NS9S/10616508_813110688711144_8646842810416095295_n.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1412136478357-LAPVXXOGDE9NPJY8NS9S/10616508_813110688711144_8646842810416095295_n.jpg" data-image-dimensions="800x534" data-image-focal-point="0.5,0.5" alt="10616508_813110688711144_8646842810416095295_n.jpg" data-load="false" data-image-id="542b7e1ee4b05bfcb6d28dea" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1412279815796_347697"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="#">Project #24: Vaudevillains Clubhouse</a></h3><p class="" style="white-space:pre-wrap;"><strong>Vaudeville Inc. Property Partner:&nbsp;The Wellington Company. Left Bank, Cuba Mall. 17 October - 1 November. For more information go</strong><a href="/vaudevillains-clubhouse"><strong> here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1411004466496_45828"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="#">Project #22: AuraSecure</a></h3><p class="" style="white-space:pre-wrap;"><strong>Terri te Tau. Property Partner: DNZ Property Ltd.&nbsp; 1 Grey Street (across from Intercontinental Hotel). 27 September - 5 October 2014. More information </strong><a href="/aura-secure"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1411004466496_134503"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/dirty-laundry">Project #23: Dirty Laundry</a></h3><p class="" style="white-space:pre-wrap;"><strong>The Hori. Property Partner: Positively Wellington Tourism. 101 Wakefield Street (across from Lido Cafe). 27 September - 12 October. More information </strong><a href="/dirty-laundry"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="66.66666666666666" data-block-type="5" id="block-yui_3_17_2_1_1410392579849_100149"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:960px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/sounding-out-vacancy"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.66666412353516%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1417595213980-X12X4UV12EKYHO6DOYF8/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1417595213980-X12X4UV12EKYHO6DOYF8/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1417595213980-X12X4UV12EKYHO6DOYF8/image-asset.jpeg" data-image-dimensions="960x720" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="547ec94de4b04e450c94e0f8" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1410392579849_108632"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/sounding-out-vacancy">Project #21: Sounding Out Vacancy</a></h3><p class="" style="white-space:pre-wrap;"><strong>Julieanna Preston. Property Partner: DNZ Property Fund Ltd. 1 Grey Street, Wellington. 16 - 23 September. Closing 6-8pm 23 September. More information </strong><a href="/sounding-out-vacancy"><strong>here.</strong></a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="67.66169154228857" data-block-type="5" id="block-yui_3_17_2_1_1410392579849_45240"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/urban-bodies"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:67.66168975830078%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1410404243203-O7X63JDYBTZVV8H9D91Y/Urban+Bodies%2C+Morphic+Assemblies+space1.jpg" alt="Urban Bodies, Morphic Assemblies space1.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1410404243203-O7X63JDYBTZVV8H9D91Y/Urban+Bodies%2C+Morphic+Assemblies+space1.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1410404243203-O7X63JDYBTZVV8H9D91Y/Urban+Bodies%2C+Morphic+Assemblies+space1.jpg" data-image-dimensions="2500x1875" data-image-focal-point="0.5,0.5" alt="Urban Bodies, Morphic Assemblies space1.jpg" data-load="false" data-image-id="54110f93e4b06e9036eb5533" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1410392579849_54716"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/urban-bodies">Project #20: Urban Bodies</a></h3><p class="" style="white-space:pre-wrap;"><strong>Tomas Richards. Property Partner - Positively Wellington Tourism. 101 Wakefield Street (across from Lido Cafe). 14- 20 September 2014, 9am-5pm. More information </strong><a href="/urban-bodies"><strong>here</strong></a><strong> and </strong><a href="https://www.facebook.com/events/527597710673607/?fref=ts" target="_blank"><strong>here</strong></a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="66.16915422885572" data-block-type="5" id="block-yui_3_17_2_1_1409194059192_94943"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:800px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/political-cuts"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.16915130615234%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1409706273760-JSA6V002P90HLH7NXKUA/10498628_1541747852712103_6277194171646916141_o.jpg" alt="10498628_1541747852712103_6277194171646916141_o.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1409706273760-JSA6V002P90HLH7NXKUA/10498628_1541747852712103_6277194171646916141_o.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1409706273760-JSA6V002P90HLH7NXKUA/10498628_1541747852712103_6277194171646916141_o.jpg" data-image-dimensions="800x534" data-image-focal-point="0.5,0.5" alt="10498628_1541747852712103_6277194171646916141_o.jpg" data-load="false" data-image-id="54066921e4b017ae41b5738a" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1409194059192_102160"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/political-cuts" target="_blank">Project #19: Political Cuts</a></h3><p class="" style="white-space:pre-wrap;"><strong>Barbarian Productions. Property partner: Positively Wellington Tourism. 101 Wakefield Street (former Nui Cafe). 1-5 September. Project information and images</strong><a href="/political-cuts"><strong> here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1408530246843_288565"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:100%;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/imaginarium"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:74.90494537353516%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1409798572689-ZHHWTONZOYOB4ENV5H86/15-49-21_23-08-14.jpg" alt="15-49-21_23-08-14.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1409798572689-ZHHWTONZOYOB4ENV5H86/15-49-21_23-08-14.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1409798572689-ZHHWTONZOYOB4ENV5H86/15-49-21_23-08-14.jpg" data-image-dimensions="526x394" data-image-focal-point="0.5,0.5" alt="15-49-21_23-08-14.jpg" data-load="false" data-image-id="5407d1ace4b0ab37159a0be7" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1408530246843_234193"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/imaginarium">Project #18: Imaginarium</a></h3><p class="" style="white-space:pre-wrap;"><strong>Reading Cinema, Courtenay Place. Property partner: Reading Courtenay Central/ CBRE. 23 August - 15 September. 12-6pm Wednesday - Saturday. Project information&nbsp;</strong><a href="/imaginarium"><strong>here</strong></a><strong>. </strong></p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_10_1_1_1400714591905_40117"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:960px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/nothing-but-precious"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.04166412353516%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1401762420317-LDY6T03ZO9BE4MJ9LXGE/Mary+Whalley%2C+Carrying+piece%2C+Filmed+by+Jason+Wright%2C+2014.jpg" alt="Mary Whalley, Carrying piece, Filmed by Jason Wright, 2014.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1401762420317-LDY6T03ZO9BE4MJ9LXGE/Mary+Whalley%2C+Carrying+piece%2C+Filmed+by+Jason+Wright%2C+2014.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1401762420317-LDY6T03ZO9BE4MJ9LXGE/Mary+Whalley%2C+Carrying+piece%2C+Filmed+by+Jason+Wright%2C+2014.jpg" data-image-dimensions="960x634" data-image-focal-point="0.5,0.5" alt="Mary Whalley, Carrying piece, Filmed by Jason Wright, 2014.jpg" data-load="false" data-image-id="538d3274e4b08a8b36a0140e" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_10_1_1_1400714591905_46831"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/nothing-but-precious">Project #15: Nothing But Precious</a><a href="#"> &nbsp;</a></h3><p class="" style="white-space:pre-wrap;"><strong>Elbowroom - The Moving Gallery. Cnr Torrens Terrace and Webb Street. Property Partner:&nbsp;Nidus Properties Ltd. 28 May - 14 June 2014 .</strong> <a href="/nothing-but-precious">Project information here.</a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1408530246843_282234"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:960px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/long-cloud-theatre"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:75%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1410307968836-MTX8Y7TH2WG6WKYSQY0S/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1410307968836-MTX8Y7TH2WG6WKYSQY0S/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1410307968836-MTX8Y7TH2WG6WKYSQY0S/image-asset.jpeg" data-image-dimensions="960x720" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="540f9780e4b04939fb5b4b41" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1408530246843_88381"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/long-cloud-theatre">Project #17: Mountebank</a></h3><p class="" style="white-space:pre-wrap;"><strong>Long Cloud Youth Theatre. 109 Dixon Street. Property p: Overton Holdings/ Baileys Property Services Ltd. 4 - 12 September. Project information&nbsp;</strong><a href="/long-cloud-theatre"><strong>here</strong></a><strong>. Website&nbsp;</strong><a href="http://www.themountebank.co.nz" target="_blank"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_10_1_1_1400714591905_172406"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2000px;"
+        >
+          
+        
+        
+
+        
+          
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.75%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1400715664736-TDS102NBY13MFYHQ968K/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1400715664736-TDS102NBY13MFYHQ968K/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1400715664736-TDS102NBY13MFYHQ968K/image-asset.jpeg" data-image-dimensions="2000x1335" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="537d3990e4b0404fb5ca3e12" data-type="image" />
+                
+            </div>
+          </div>
+        
+          
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_10_1_1_1400714591905_204604"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/moodbank">Project #14: Moodbank&nbsp;</a></h3><p class="" style="white-space:pre-wrap;"><strong>Vanessa&nbsp;Crowe and Dr Sarah Baker. 29 Manners Street.&nbsp;Property Partner: Shoreline Property Group. March 2014.&nbsp;10am - 8pm.&nbsp;</strong><a href="/moodbank">Project information here.</a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_1_1408530246843_272452"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:640px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/battle-hymn"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:75%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1410310704419-D5MYSVOPCGA9BBUYDJK0/14-36-43_07-08-14.jpg" alt="14-36-43_07-08-14.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1410310704419-D5MYSVOPCGA9BBUYDJK0/14-36-43_07-08-14.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1410310704419-D5MYSVOPCGA9BBUYDJK0/14-36-43_07-08-14.jpg" data-image-dimensions="640x480" data-image-focal-point="0.5,0.5" alt="14-36-43_07-08-14.jpg" data-load="false" data-image-id="540fa230e4b07898251f78ba" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1408530246843_79497"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/battle-hymn">Project #16:&nbsp;Battle Hymn</a></h3><p class="" style="white-space:pre-wrap;"><strong>Red Scare Collective.&nbsp;114 Cuba Street (Left Bank).&nbsp;Property partner: The Wellington Company.&nbsp;18 - 20 September 2014. Project information </strong><a href="/battle-hymn"><strong>here</strong></a><strong>. Production website&nbsp;</strong><a href="http://www.redscarecollective.com" target="_blank"><strong>here</strong></a><strong>.</strong></p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-ddccd67e34cba6cf2dac"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2000px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/the-waiting-room"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.75%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1400013799239-BJOQIW80E2PTSO5RBYC8/waiting-room.jpg" alt="waiting-room.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1400013799239-BJOQIW80E2PTSO5RBYC8/waiting-room.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1400013799239-BJOQIW80E2PTSO5RBYC8/waiting-room.jpg" data-image-dimensions="2000x1335" data-image-focal-point="0.5,0.5" alt="waiting-room.jpg" data-load="false" data-image-id="537283e7e4b0d7a46b2df057" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-c692e6d2200ff9867edd"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/the-waiting-room">Project #13: The Waiting Room</a></h3><p class="" style="white-space:pre-wrap;"><strong>Victoria Singh. 123 Cuba&nbsp;Street. Property Partner: Anonymous. March 2014. </strong><a href="/the-waiting-room">Project information here.</a></p>
+</div>
+
+
+
+</div></div></div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="76.5" data-block-type="5" id="block-81dcb03bfd2bb7230672"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:100%;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/midsummer"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:76.5%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1393556697240-C3HKUAP3ZT9NTFU9HP7I/IMG_0050.jpeg" alt="IMG_0050.jpeg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1393556697240-C3HKUAP3ZT9NTFU9HP7I/IMG_0050.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1393556697240-C3HKUAP3ZT9NTFU9HP7I/IMG_0050.jpeg" data-image-dimensions="800x534" data-image-focal-point="0.5,0.5" alt="IMG_0050.jpeg" data-load="false" data-image-id="530ffcd9e4b0aa9562867bd0" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="76" data-block-type="5" id="block-176f4a1172ae8c675cdf"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:100%;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          content-fill
+        
+              "
+              href="/java-dance"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          content-fill
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:76%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1390955903342-11LDAZ6U0BDKDB92IR1O/RISE-001.jpg" alt="RISE-001.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1390955903342-11LDAZ6U0BDKDB92IR1O/RISE-001.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1390955903342-11LDAZ6U0BDKDB92IR1O/RISE-001.jpg" data-image-dimensions="2500x1668" data-image-focal-point="0.5,0.5" alt="RISE-001.jpg" data-load="false" data-image-id="52e84d7fe4b04e00fe3465c5" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="74.5" data-block-type="5" id="block-41b025cd3cea3c2a2ffe"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:100%;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          content-fill
+        
+              "
+              href="/new-gallery"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          content-fill
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:74.5%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1382664004839-W36KV9EPWUMR3B7C84BV/13-23-27_23-10-13.jpg" alt="13-23-27_23-10-13.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1382664004839-W36KV9EPWUMR3B7C84BV/13-23-27_23-10-13.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1382664004839-W36KV9EPWUMR3B7C84BV/13-23-27_23-10-13.jpg" data-image-dimensions="800x600" data-image-focal-point="0.5,0.5" alt="13-23-27_23-10-13.jpg" data-load="false" data-image-id="5269c744e4b0eb2b76cc60a7" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-5b1d8e5e0ca06f98d6e2"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/midsummer">Project #12:&nbsp;A Midsummer Night's Dream</a></h3><p class="" style="white-space:pre-wrap;"><strong>A Bright Orange Walls Production.&nbsp;185 Victoria Street, Wellington.&nbsp;Property Partner: Portfolia. February 2014. </strong><a href="/midsummer">Information and images.&nbsp;</a></p><p class="" data-rte-preserve-empty="true" style="white-space:pre-wrap;"></p><p class="" data-rte-preserve-empty="true" style="white-space:pre-wrap;"></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-d778d134b5112e3acec2"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/java-dance">Project #11: Java Dance</a></h3><p class="" style="white-space:pre-wrap;"><strong>A Java Installation. 88-92 Riddford Street, Newtown. Property Partner: Mark Horsfall Properties. November 2013. </strong><a href="/java-dance">Information and images.</a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-0c673fd8a19ee55b3d4a"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/new-gallery">Project #10: Digital Biophilia</a></h3><p class="" style="white-space:pre-wrap;"><strong>Cnr Bowen St &amp; Lambton Quay. Property Partner: Bowen House Holdings Ltd. October 2013. </strong><a href="/new-gallery">Information and images.</a></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="67" data-block-type="5" id="block-9e6e19e779a576ecd95f"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:100%;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/broken-river"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:67%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1393557863951-O6NHIHT7BPZO6LL237WN/14-39-02_14-11-13.jpg" alt="14-39-02_14-11-13.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1393557863951-O6NHIHT7BPZO6LL237WN/14-39-02_14-11-13.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1393557863951-O6NHIHT7BPZO6LL237WN/14-39-02_14-11-13.jpg" data-image-dimensions="2500x1875" data-image-focal-point="0.5,0.5" alt="14-39-02_14-11-13.jpg" data-load="false" data-image-id="53100167e4b0e44d7fb20ddc" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-8df8f0d69f59fbadbcf9"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/broken-river">Project #9: Broken River</a></h3><p class="" style="white-space:pre-wrap;"><strong>Trick of the Light Theatre.&nbsp;Eagle Technology House, Victoria Street. October&nbsp;- December 2013.&nbsp;Property Partner: Oyster Group. </strong><a href="/broken-river">Information and images.</a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-ef4efd52e2da32cf1756"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:640px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/cleave"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.5625%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1379648261810-RED3PC85F553EDLXJ4QH/cleavehomepage.jpg" alt="cleavehomepage.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1379648261810-RED3PC85F553EDLXJ4QH/cleavehomepage.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1379648261810-RED3PC85F553EDLXJ4QH/cleavehomepage.jpg" data-image-dimensions="640x426" data-image-focal-point="0.5,0.5" alt="cleavehomepage.jpg" data-load="false" data-image-id="523bc305e4b0d4585704689c" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-5e54b2258f0cc5106125"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/cleave">Project #8: Cleave</a></h3><p class="" style="white-space:pre-wrap;"><strong>Gabby O'Connor.&nbsp;86 - 96 Victoria Street, Wellington.&nbsp;June - July 2013.&nbsp;Property Partner: Prime Property Group. </strong><a href="/cleave">Information and images.</a></p><p style="text-align:right;white-space:pre-wrap;" class="">&nbsp;</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-8ba4632edab8814c3a4f"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:100%;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="/dying-city"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:66.40625%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1393558609213-ZAI590OYCN1B0CWWAM55/fc-20130612-00106-DSC_3586.jpg" alt="fc-20130612-00106-DSC_3586.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1393558609213-ZAI590OYCN1B0CWWAM55/fc-20130612-00106-DSC_3586.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1393558609213-ZAI590OYCN1B0CWWAM55/fc-20130612-00106-DSC_3586.jpg" data-image-dimensions="640x425" data-image-focal-point="0.5,0.5" alt="fc-20130612-00106-DSC_3586.jpg" data-load="false" data-image-id="53100451e4b0e44d7fb213c6" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-347821bea16b94495dde"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/dying-city">Project #7: Tales of a Dying City</a></h3><p class="" style="white-space:pre-wrap;"><strong>A Slightly&nbsp;Isolated&nbsp;Dog. Grand Arcade, Willis Street. June 2013.&nbsp;Property Partner: Grand Complex Properties/Jones Lang LeSalle. </strong><a href="/dying-city">Information and images.&nbsp;</a></p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="75.5" data-block-type="5" id="block-19a2e467028bc1c95058"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:2500px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          content-fill
+        
+              "
+              href="/occupation"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          content-fill
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:75.5%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1368585862982-JPMI79IS150QE5FJ8G0Y/P1060408.JPG" alt="P1060408.JPG" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1368585862982-JPMI79IS150QE5FJ8G0Y/P1060408.JPG" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1368585862982-JPMI79IS150QE5FJ8G0Y/P1060408.JPG" data-image-dimensions="2500x3333" data-image-focal-point="0.5,0.5" alt="P1060408.JPG" data-load="false" data-image-id="5192f686e4b0356188b80331" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-13c320bb63081676030b"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/occupation">Project #6: Occupation Artists</a></h3><p class="" style="white-space:pre-wrap;"><strong>Grand Arcade, Willis Street. June - November 2013.&nbsp;Property Partner: Grand Complex Properties Ltd / Jones Lang LeSalle. </strong><a href="/occupation">Information and images.</a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-8 span-8"><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="74.5" data-block-type="5" id="block-30568a84d5758f00d6ed"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:100%;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          content-fill
+        
+              "
+              href="/brides"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          content-fill
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:74.5%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1393560308725-XDOED9VU3PSZ62LID9JF/posing.JPG" alt="posing.JPG" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1393560308725-XDOED9VU3PSZ62LID9JF/posing.JPG" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1393560308725-XDOED9VU3PSZ62LID9JF/posing.JPG" data-image-dimensions="960x720" data-image-focal-point="0.5,0.5" alt="posing.JPG" data-load="false" data-image-id="53100af4e4b0fe3537f2d0d6" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-c541ea5b86a9e218e282"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/brides">Project #5: Brides<em>&nbsp;</em></a></h3><p class="" style="white-space:pre-wrap;"><strong>Bowen House, Cnr Lambton Quay and Bowen Street. April 2013. Property Partner: Bowen Holdings Ltd.</strong>&nbsp;<a href="#" target="_blank">Information and images.&nbsp;</a></p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="73.5" data-block-type="5" id="block-b525c5909d772ca34aac"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:100%;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          content-fill
+        
+              "
+              href="/peoples-cinema"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          content-fill
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:73.5%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1372390077909-E0RMRRIXCVYGD19KAILN/fc-20130617-00011-DSC_3732.jpg" alt="fc-20130617-00011-DSC_3732.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1372390077909-E0RMRRIXCVYGD19KAILN/fc-20130617-00011-DSC_3732.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1372390077909-E0RMRRIXCVYGD19KAILN/fc-20130617-00011-DSC_3732.jpg" data-image-dimensions="2500x1396" data-image-focal-point="0.5,0.5" alt="fc-20130617-00011-DSC_3732.jpg" data-load="false" data-image-id="51cd02bde4b00280d0e73836" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-ef274cca711e156c57e9"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/occupation">Project #4: People's Cinema&nbsp;</a></h3><p class="" style="white-space:pre-wrap;"><strong>57 Manners Street. From April 2013. Property Partner: The Wellington Company. </strong><a href="/peoples-cinema">Information and images.</a></p>
+</div>
+
+
+
+</div></div></div></div></div></div><div class="row sqs-row"><div class="col sqs-col-8 span-8"><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="74" data-block-type="5" id="block-e73c99e86b405ef3291b"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:100%;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          content-fill
+        
+              "
+              href="http://urbandreambrokerage.org.nz/blog/2013/2/8/a-slinky-a-treadmill-a-bat-a-record-player-a-pair-of-dice-and-a-foot-spa"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          content-fill
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:74%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1361926928644-GZZPRPY3PVE3I21MZJAO/status-quo.jpg" alt="status-quo.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1361926928644-GZZPRPY3PVE3I21MZJAO/status-quo.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1361926928644-GZZPRPY3PVE3I21MZJAO/status-quo.jpg" data-image-dimensions="615x427" data-image-focal-point="0.5,0.5" alt="status-quo.jpg" data-load="false" data-image-id="512d5b10e4b0fc5465700ffb" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-783a456dde7993409fb1"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:640px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          content-fill
+        
+              "
+              href="/your-message-here"
+              
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          content-fill
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:75%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1394567357225-RYRAGH1KQLYW8CS2ZGEH/daniel+and+kirsty.jpg" alt="daniel and kirsty.jpg" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1394567357225-RYRAGH1KQLYW8CS2ZGEH/daniel+and+kirsty.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1394567357225-RYRAGH1KQLYW8CS2ZGEH/daniel+and+kirsty.jpg" data-image-dimensions="640x480" data-image-focal-point="0.5,0.5" alt="daniel and kirsty.jpg" data-load="false" data-image-id="531f68bde4b094aec2540537" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div></div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-509b75a2be7127aa8ec9"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:100%;"
+        >
+          
+        
+        
+
+        
+          
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          content-fill
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:74.68000030517578%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1366153435811-AWYN9ZGXF6JYF8N1NP6P/IMG_0699.JPG" alt="IMG_0699.JPG" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1366153435811-AWYN9ZGXF6JYF8N1NP6P/IMG_0699.JPG" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1366153435811-AWYN9ZGXF6JYF8N1NP6P/IMG_0699.JPG" data-image-dimensions="2500x1867" data-image-focal-point="0.5,0.5" alt="IMG_0699.JPG" data-load="false" data-image-id="516dd8dbe4b005d966f8f0ab" data-type="image" />
+                
+            </div>
+          </div>
+        
+          
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-095c5a75c0d3fd8c2980"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/status-quo">Project #1: Status Quo</a></h3><p class="" style="white-space:pre-wrap;"><strong>James R Ford.&nbsp;120 Courtenay Place.&nbsp;February - March 2013. Property partner: Frank Wong on behalf of Wong Wung Partnership.</strong> <a href="/status-quo">Information and images.</a></p>
+</div>
+
+
+
+</div></div><div class="sqs-block image-block sqs-block-image" data-block-type="5" id="block-yui_3_17_2_3_1457993876134_115776"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+  
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:620px;"
+        >
+          
+        
+        
+
+        
+          
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:61.29032516479492%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1457994012692-8K70U60DSX0TKTIF7NIT/image-asset.jpeg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1457994012692-8K70U60DSX0TKTIF7NIT/image-asset.jpeg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/1457994012692-8K70U60DSX0TKTIF7NIT/image-asset.jpeg" data-image-dimensions="620x380" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="56e7391c62cd940c184b8018" data-type="image" />
+                
+            </div>
+          </div>
+        
+          
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+
+</div></div><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1634179800233_264131"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/17-tory-street">PROJECT #0: 17 TORY STREET</a></h3><p class="" style="white-space:pre-wrap;">Concerned Citizens Collective. 17 Tory Street. April 2012 - ongoing. Property partner: Michael Baker. <a href="/17-tory-street">Information and images.</a></p><h3 style="white-space:pre-wrap;">&nbsp;</h3><p class="" style="white-space:pre-wrap;">&nbsp;</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-2fe3645d7f59dc0c9025"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/your-message-here">Project #2: Your Message Here</a></h3><p class="" style="white-space:pre-wrap;"><strong>Daniel Webby. 86-96 Victoria Street. March 2013. Property partner: Prime Property Group.</strong><a href="/your-message-here"> Information and images.</a></p><p class="" data-rte-preserve-empty="true" style="white-space:pre-wrap;"></p><p class="" style="white-space:pre-wrap;">&nbsp;</p>
+</div>
+
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-8e4e6be6e5d40df03cc4"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="white-space:pre-wrap;"><a href="/serpent">Project #3:&nbsp;Scales of the Serpent</a></h3><p class="" style="white-space:pre-wrap;"><strong>Tessa Laird, March - May 2013. Opposite 19 Tory Street. Property partner: Reading Cinema and Care Park. </strong><a href="/serpent">Information and images.</a></p><p class="" style="white-space:pre-wrap;">&nbsp;</p>
+</div>
+
+
+
+</div></div></div></div><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="sqs-block html-block sqs-block-html" data-block-type="2" id="block-yui_3_17_2_1_1634179800233_297969"><div class="sqs-block-content">
+
+<div class="sqs-html-content">
+  <h3 style="text-align:center;white-space:pre-wrap;">Urban Dream Brokerage is run with the support of Wellington City Council and Wellington Community Trust</h3>
+</div>
+
+
+
+</div></div></div></div></div>
+
+    </section>
+
+    <div class="sqs-layout sqs-grid-12 columns-12 empty" data-layout-label="Footer Content: Home" data-type="block-field" data-updated-on="1606196528426" id="collection-508a094ee4b0f50834e1e3eb"><div class="row sqs-row"><div class="col sqs-col-12 span-12"></div></div></div>
+
+    <!-- <div class="page-divider bottom-divider"></div> -->
+
+    <div class="info-footer-wrapper clear">
+      <div class="info-footer">
+      <div class="sqs-layout sqs-grid-12 columns-12 empty" data-layout-label="Info Footer Content" data-type="block-field" id="infoFooterBlock"><div class="row sqs-row"><div class="col sqs-col-12 span-12"></div></div></div>
+      
+        
+        <div id="socialLinks" class="social-links" data-content-field="connected-accounts">
+          <a href="https://fb.me/e/3tDkNEgsf" target="_blank" class="social-facebook-unauth"></a>
+        </div>
+        
+      
+      </div>
+    </div>
+
+    <footer id="footer">
+      <div class="sqs-layout sqs-grid-12 columns-12" data-layout-label="Footer Content" data-type="block-field" data-updated-on="1676408954437" id="footerBlock"><div class="row sqs-row"><div class="col sqs-col-12 span-12"><div class="row sqs-row"><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="12.9973474801061" data-block-type="5" id="block-yui_3_17_2_2_1441141891441_4724"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-hidden
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:3212px;"
+        >
+          
+        
+        
+
+        
+          
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:12.997347831726074%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/42b7ab04-e3b7-4e9d-a305-2d4e6f822611/Aho+tini+banner.png" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/42b7ab04-e3b7-4e9d-a305-2d4e6f822611/Aho+tini+banner.png" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/42b7ab04-e3b7-4e9d-a305-2d4e6f822611/Aho+tini+banner.png" data-image-dimensions="3212x490" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="63ebf665946ad2337d39b900" data-type="image" />
+                
+            </div>
+          </div>
+        
+          
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="29.375" data-block-type="5" id="block-yui_3_17_2_2_1449541775858_9726"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:945px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="http://wellington.govt.nz"
+              target="_blank"
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:29.375%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/549b4846-d745-4e7d-88fa-504fb0b2ca64/WCC-Logo-Black-Web.png" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/549b4846-d745-4e7d-88fa-504fb0b2ca64/WCC-Logo-Black-Web.png" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/549b4846-d745-4e7d-88fa-504fb0b2ca64/WCC-Logo-Black-Web.png" data-image-dimensions="945x295" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="63ebf7c9964020555d2aebe8" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div><div class="sqs-block socialaccountlinks-v2-block sqs-block-socialaccountlinks-v2" data-block-type="54" id="block-yui_3_17_2_1_1668570749464_18594"><div class="sqs-block-content">
+
+
+
+<div class="sqs-svg-icon--outer social-icon-alignment-center social-icons-color-black social-icons-size-large social-icons-shape-rounded social-icons-style-border" >
+  <style>
+    #block-yui_3_17_2_1_1668570749464_18594 .social-icons-style-border .sqs-svg-icon--wrapper {
+      
+        box-shadow: 0 0 0 2px inset;
+      
+      border: none; 
+    }
+  </style>
+  <nav class="sqs-svg-icon--list">
+    <a href="https://fb.me/e/3tDkNEgsf" target="_blank" class="sqs-svg-icon--wrapper facebook-unauth" aria-label="Facebook">
+      <div>
+        <svg class="sqs-svg-icon--social" viewBox="0 0 64 64">
+          <use class="sqs-use--icon" xlink:href="#facebook-unauth-icon"></use>
+          <use class="sqs-use--mask" xlink:href="#facebook-unauth-mask"></use>
+        </svg>
+      </div>
+    </a>
+  </nav>
+</div>
+</div></div></div><div class="col sqs-col-4 span-4"><div class="sqs-block image-block sqs-block-image" data-aspect-ratio="35.0132625994695" data-block-type="5" id="block-yui_3_17_2_3_1449529667690_6314"><div class="sqs-block-content">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  
+
+    
+  
+    <div
+        class="
+          image-block-outer-wrapper
+          layout-caption-below
+          design-layout-inline
+          combination-animation-none
+          individual-animation-none
+          individual-text-animation-none
+        "
+        data-test="image-block-inline-outer-wrapper"
+    >
+
+      
+
+      
+        <figure
+            class="
+              sqs-block-image-figure
+              intrinsic
+            "
+            style="max-width:1873px;"
+        >
+          
+        
+        
+
+        
+          <a
+              class="
+                sqs-block-image-link
+                
+          
+        
+              "
+              href="http://www.dunedin.govt.nz"
+              target="_blank"
+          >
+            
+          <div
+              
+              
+              class="image-block-wrapper"
+              data-animation-role="image"
+              
+  
+
+          >
+            <div class="sqs-image-shape-container-element
+              
+          
+        
+              has-aspect-ratio
+            " style="
+                position: relative;
+                
+                  padding-bottom:35.01326370239258%;
+                
+                overflow: hidden;-webkit-mask-image: -webkit-radial-gradient(white, black);
+              "
+              >
+                
+                  <noscript><img src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/dc1e60d4-9d9c-45b9-9c98-c6520db2dd96/CCS_logo_Wellington.jpg" alt="" /></noscript><img class="thumb-image" data-src="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/dc1e60d4-9d9c-45b9-9c98-c6520db2dd96/CCS_logo_Wellington.jpg" data-image="https://images.squarespace-cdn.com/content/v1/508a094ee4b0f50834e1e3d6/dc1e60d4-9d9c-45b9-9c98-c6520db2dd96/CCS_logo_Wellington.jpg" data-image-dimensions="1873x654" data-image-focal-point="0.5,0.5" alt="" data-load="false" data-image-id="62cce39e77cebd1b0dfc616f" data-type="image" />
+                
+            </div>
+          </div>
+        
+          </a>
+        
+
+        
+      
+        </figure>
+      
+
+    </div>
+  
+
+
+  
+
+
+</div></div></div></div></div></div></div>
+    </footer>
+
+  </div>
+
+  <div></div>
+
+  <script data-sqs-type="imageloader-bootstrapper">if(window.ImageLoader) window.ImageLoader.bootstrap({}, document);</script><script>Squarespace.afterBodyLoad(Y);</script><svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="display:none" data-usage="social-icons-svg"><symbol id="facebook-unauth-icon" viewBox="0 0 64 64"><path d="M34.1,47V33.3h4.6l0.7-5.3h-5.3v-3.4c0-1.5,0.4-2.6,2.6-2.6l2.8,0v-4.8c-0.5-0.1-2.2-0.2-4.1-0.2 c-4.1,0-6.9,2.5-6.9,7V28H24v5.3h4.6V47H34.1z"/></symbol><symbol id="facebook-unauth-mask" viewBox="0 0 64 64"><path d="M0,0v64h64V0H0z M39.6,22l-2.8,0c-2.2,0-2.6,1.1-2.6,2.6V28h5.3l-0.7,5.3h-4.6V47h-5.5V33.3H24V28h4.6V24 c0-4.6,2.8-7,6.9-7c2,0,3.6,0.1,4.1,0.2V22z"/></symbol></svg>
+
+
+
+</body>
+
+</html>

--- a/src/test/scala/nz/co/searchwellington/linkchecking/PageContentHasherTest.scala
+++ b/src/test/scala/nz/co/searchwellington/linkchecking/PageContentHasherTest.scala
@@ -1,0 +1,25 @@
+package nz.co.searchwellington.linkchecking
+
+import org.apache.commons.io.IOUtils
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class PageContentHasherTest {
+
+  private val hasher = new PageContentHasher
+
+  @Test
+  def shouldReturnSameHashForPagesWithSameContentEvenIfTheNonUserVisibleHTMLeDiffers(): Unit = {
+    val before = loadTestFile("urbandreambrokerage_1.html")
+    val after = loadTestFile("urbandreambrokerage_2.html")
+
+    assertEquals(hasher.hashPageContent(before), hasher.hashPageContent(after))
+  }
+
+  private def loadTestFile(filename: String): String = {
+    IOUtils.toString(this.getClass.getClassLoader.getResourceAsStream(filename),
+      java.nio.charset.StandardCharsets.UTF_8
+    )
+  }
+
+}


### PR DESCRIPTION
Given an example of a watchlist page which has infrequent content changes but a very wobbly updated content signal, we can improve this by only considering the plain text of the HTML page.

In this example, the script assets have unstable URLs but this does not effect the visible content of the page.