### PR TITLE
Link checker uses last scanned date as an idempotency hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ See detecting page changes (below)[(#detecting-changes)].
 ### Feed acceptance policy
 
 Describes how the feed reader should treat feed items in a particular feed.
-Most feeds always contain relevant and approriate content which can be automatically accepted; some don't.
+Most feeds always contain relevant and appropriate content which can be automatically accepted; some don't.
 The feed acceptance policy helps document which feeds require manual moderation.
 
 `ACCEPT`

--- a/src/main/scala/nz/co/searchwellington/controllers/ManageResourceController.scala
+++ b/src/main/scala/nz/co/searchwellington/controllers/ManageResourceController.scala
@@ -2,6 +2,7 @@ package nz.co.searchwellington.controllers
 
 import jakarta.servlet.http.HttpServletRequest
 import nz.co.searchwellington.ReasonableWaits
+import nz.co.searchwellington.linkchecking.LinkCheckRequest
 import nz.co.searchwellington.model.{Resource, User}
 import nz.co.searchwellington.modification.ContentDeletionService
 import nz.co.searchwellington.permissions.EditPermissionService
@@ -32,7 +33,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
     def checkResource(loggedInUser: User): ModelAndView = {
       getResourceById(id).map { resource =>
         log.info("Adding resource to queue: " + resource.id + "(" + resource._id.stringify + ")")
-        queue.add(resource._id.stringify)
+        queue.add(new LinkCheckRequest(resourceId = resource._id.stringify, lastScanned = resource.last_scanned))
         new ModelAndView(new RedirectView(urlStack.getExitUrlFromStack(request)))
       }
     }.getOrElse {

--- a/src/main/scala/nz/co/searchwellington/linkchecking/LinkCheckRequest.scala
+++ b/src/main/scala/nz/co/searchwellington/linkchecking/LinkCheckRequest.scala
@@ -1,0 +1,5 @@
+package nz.co.searchwellington.linkchecking
+
+import java.util.Date
+
+case class LinkCheckRequest(resourceId: String, lastScanned: Option[Date])

--- a/src/main/scala/nz/co/searchwellington/linkchecking/LinkChecker.scala
+++ b/src/main/scala/nz/co/searchwellington/linkchecking/LinkChecker.scala
@@ -15,7 +15,7 @@ import reactivemongo.api.bson.BSONObjectID
 
 import java.net.{URL, UnknownHostException}
 import java.util.Date
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
 import scala.util.Try
 
@@ -41,49 +41,42 @@ import scala.util.Try
   // load the resource.
   // If it has a url fetch the url and process the loaded page
   // Update the last scanned timestamp
-  def scanResource(resourceId: String, idempotency: Option[Date])(implicit ec: ExecutionContext): Future[Boolean] = {
+  def scanResource(resourceId: String, idempotencyValue: Option[Date])(implicit ec: ExecutionContext): Future[Boolean] = {
     log.info("Scanning resource: " + resourceId)
     val objectId = BSONObjectID.parse(resourceId).get
 
-    val eventualResult = for {
-      maybeResourceWithUrl <- mongoRepository.getResourceByObjectId(objectId)
-      result <- maybeResourceWithUrl.map { resource =>
+    // Load the resource and check it's idempotency value synchronously
+    // Dispatch a future after the idempotency check
+    val maybeResource = Await.result(mongoRepository.getResourceByObjectId(objectId), TenSeconds)
+
+    maybeResource.map { resource =>
+      val isNotDuplicateRequest = resource.last_scanned == idempotencyValue
+      if (isNotDuplicateRequest) {
         log.info("Checking: " + resource.title + " (" + resource.page + ")")
+        val now = Some(DateTime.now.toDate)
+        log.info("Marking idempotency value for: " + resource.title + " as: " + now)
+        resource.last_scanned = now
+        Await.result(contentUpdateService.update(resource), TenSeconds)
 
-        if (resource.last_scanned == idempotency) {
-          log.info("Checking: " + resource.title + " (" + resource.page + ")")
-          checkResource(resource).flatMap { outcome =>
-            resource.last_scanned = Some(DateTime.now.toDate)
-            contentUpdateService.update(resource).map { _ =>
-              checkedCounter.increment()
-              log.info("Finished link checking")
-              outcome
-            }
-          }
-
-        } else {
-          log.info("Skipping link check for " + resource.title + " as it has already been checked with idempotency: " + idempotency + " / " + resource.last_scanned)
-          duplicateCounter.increment()
-          Future.successful(false)
+        // Now that the idempotency value has been updated we can dispatch a future safe from duplicates
+        checkResource(resource).map { outcome =>
+          checkedCounter.increment()
+          log.info("Finished link checking")
+          outcome
         }
 
-      }.getOrElse {
-        log.warn("Link checker was past an unknown resource id: " + resourceId + " / " + objectId.stringify)
-        failedCounter.increment()
+      } else {
+        log.info("Skipping link check for " + resource.title + " as it has already been checked with idempotency: " + idempotencyValue + " / " + resource.last_scanned)
+        duplicateCounter.increment()
         Future.successful(false)
-
-      }.recoverWith {
-        case e: Exception =>
-          log.error("Link check failed: " + e.getMessage, e)
-          failedCounter.increment()
-          Future.successful(false)
       }
 
-    } yield {
-      result
+    }.getOrElse {
+      log.warn("Link checker was past an unknown resource id: " + resourceId + " / " + objectId.stringify)
+      failedCounter.increment()
+      Future.successful(false)
     }
 
-    eventualResult
   }
 
   // Given a URL load it and return the http status and the page contents
@@ -93,7 +86,7 @@ import scala.util.Try
       log.info("Http status for " + url + " set was: " + status)
 
       val isRedirecting = status >= 300 && status < 400
-      val isMovedPermanently = status == 301  // TODO this is the useful signal we're really trying to capture here
+      val isMovedPermanently = status == 301 // TODO this is the useful signal we're really trying to capture here
       if (isRedirecting) {
         httpFetcher.httpFetch(url).map { httpResult =>
           log.info(s"Retrying fetching of $url with follow redirects")
@@ -116,11 +109,11 @@ import scala.util.Try
 
   def checkResource(resource: Resource)(implicit ec: ExecutionContext): Future[Boolean] = {
     val parsedUrl = {
-      if (urlValidator.isValid(resource.page)) {  // java.net.URL's construct is too permissive; ie. http://// // TODO Apply this everywhere
+      if (urlValidator.isValid(resource.page)) { // java.net.URL's construct is too permissive; ie. http://// // TODO Apply this everywhere
         Try {
           new java.net.URL(resource.page)
         }.toOption
-     } else {
+      } else {
         None
       }
     }

--- a/src/main/scala/nz/co/searchwellington/linkchecking/LinkChecker.scala
+++ b/src/main/scala/nz/co/searchwellington/linkchecking/LinkChecker.scala
@@ -31,6 +31,7 @@ import scala.util.Try
 
   private val checkedCounter = registry.counter("linkchecker_checked")
   private val failedCounter = registry.counter("linkchecker_failed")
+  private val duplicateCounter = registry.counter("linkchecker_duplicate")
 
   {
     log.info("Autowired " + processors.asScala.size + " link checker processors: " + processors.asScala.map(_.getClass.getCanonicalName).mkString(", "))
@@ -62,6 +63,7 @@ import scala.util.Try
 
         } else {
           log.info("Skipping link check for " + resource.title + " as it has already been checked with idempotency: " + idempotency + " / " + resource.last_scanned)
+          duplicateCounter.increment()
           Future.successful(false)
         }
 

--- a/src/main/scala/nz/co/searchwellington/modification/ContentUpdateService.scala
+++ b/src/main/scala/nz/co/searchwellington/modification/ContentUpdateService.scala
@@ -1,5 +1,6 @@
 package nz.co.searchwellington.modification
 
+import nz.co.searchwellington.linkchecking.LinkCheckRequest
 import nz.co.searchwellington.model.Resource
 import nz.co.searchwellington.queues.LinkCheckerQueue
 import nz.co.searchwellington.repositories.elasticsearch.ElasticSearchIndexRebuildService
@@ -57,7 +58,7 @@ import scala.concurrent.{ExecutionContext, Future}
       println(r)
       if (r.writeErrors.isEmpty) {
         elasticSearchIndexRebuildService.index(resource).map { _ =>
-          linkCheckerQueue.add(resource._id.stringify)
+          linkCheckerQueue.add(LinkCheckRequest(resourceId = resource._id.stringify, lastScanned = resource.last_scanned))
           true
         }
       } else {

--- a/src/main/scala/nz/co/searchwellington/queues/LinkCheckerConsumer.scala
+++ b/src/main/scala/nz/co/searchwellington/queues/LinkCheckerConsumer.scala
@@ -80,11 +80,8 @@ import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
   private def logQueueCount(channel: Channel): Unit = {
     try {
-      val ok = channel.queueDeclare(LinkCheckerQueue.QUEUE_NAME, false, false, false, null)
-      val countFromDeclare = ok.getMessageCount
       val countFromChannel = channel.messageCount(LinkCheckerQueue.QUEUE_NAME)
-
-      log.info(s"Link checker queue contains $countFromDeclare / $countFromChannel messages")
+      log.info(s"Link checker channel contains $countFromChannel ready to deliver messages")
     } catch {
       case e: Exception =>
         log.error("Error while counting messages: ", e)

--- a/src/main/scala/nz/co/searchwellington/queues/LinkCheckerQueue.scala
+++ b/src/main/scala/nz/co/searchwellington/queues/LinkCheckerQueue.scala
@@ -3,10 +3,9 @@ package nz.co.searchwellington.queues
 import io.micrometer.core.instrument.MeterRegistry
 import nz.co.searchwellington.linkchecking.LinkCheckRequest
 import org.apache.commons.logging.LogFactory
-import org.joda.time.DateTime
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import play.api.libs.json.{Json, OWrites, Writes}
+import play.api.libs.json.{Json, Writes}
 
 @Component
 class LinkCheckerQueue @Autowired()(val rabbitConnectionFactory: RabbitConnectionFactory, val registry: MeterRegistry) {
@@ -22,11 +21,11 @@ class LinkCheckerQueue @Autowired()(val rabbitConnectionFactory: RabbitConnectio
   }
 
   def add(request: LinkCheckRequest): Unit = try {
-    log.debug(s"Adding link check request to queue: $request")
 
-    implicit val dtw: Writes[DateTime] = Writes.DefaultJodaDateWrites
     implicit val lcrw: Writes[LinkCheckRequest] = Json.writes[LinkCheckRequest]
     val asJson = Json.stringify(Json.toJson(request))
+
+    log.info(s"Adding link check request to queue: $asJson")
     channel.basicPublish("", LinkCheckerQueue.QUEUE_NAME, null, asJson.getBytes)
     queuedCounter.increment()
 

--- a/src/test/scala/nz/co/searchwellington/controllers/ContentUpdateServiceTest.scala
+++ b/src/test/scala/nz/co/searchwellington/controllers/ContentUpdateServiceTest.scala
@@ -2,6 +2,7 @@ package nz.co.searchwellington.controllers
 
 import java.util.UUID
 import nz.co.searchwellington.ReasonableWaits
+import nz.co.searchwellington.linkchecking.LinkCheckRequest
 import nz.co.searchwellington.model.{Newsitem, Website}
 import nz.co.searchwellington.modification.ContentUpdateService
 import nz.co.searchwellington.queues.LinkCheckerQueue
@@ -55,7 +56,7 @@ class ContentUpdateServiceTest extends ReasonableWaits {
 
     Await.result(service.create(newResource), TenSeconds)
 
-    verify(linkCheckerQueue).add(newResource._id.stringify)
+    verify(linkCheckerQueue).add(LinkCheckRequest(newResource._id.stringify, None))
   }
 
 }


### PR DESCRIPTION
Link check requests in the link checker queue include the last_scanned date of the resource when the link check was requested.

The queue consumer blocks while it checks and updates the last_scanned date before dispatching a Future.
If the last_scanned dates do not match then a link check must have been dispatched from an identical message while this message was in the queue and we can ignore it as a duplicate.



 