### PR TITLE
Feed Read timer job queues requests onto Rabbit queue

### DIFF
--- a/src/main/scala/nz/co/searchwellington/feeds/FeedReader.scala
+++ b/src/main/scala/nz/co/searchwellington/feeds/FeedReader.scala
@@ -24,7 +24,7 @@ import scala.concurrent.{ExecutionContext, Future}
   def processFeed(feed: Feed, readingUser: User, overriddenAcceptancePolicy: Option[FeedAcceptancePolicy] = None)(implicit ec: ExecutionContext, currentSpan: Span): Future[Int] = {
     try {
       val acceptancePolicy = overriddenAcceptancePolicy.getOrElse(feed.acceptance)
-      log.debug(s"Processing feed: ${feed.title} using acceptance policy $acceptancePolicy. Last read: " + feed.last_read.getOrElse(""))
+      log.info(s"Processing feed: ${feed.title} using acceptance policy $acceptancePolicy. Last read: " + feed.last_read.getOrElse(""))
       whakaokoFeedReader.fetchFeedItems(feed).flatMap { feedItemsFetch =>
         feedItemsFetch.fold({ l =>
           log.warn("Could not fetch feed items for feed + '" + feed.title + "':" + l)

--- a/src/main/scala/nz/co/searchwellington/feeds/reading/ReadFeedConsumer.scala
+++ b/src/main/scala/nz/co/searchwellington/feeds/reading/ReadFeedConsumer.scala
@@ -1,0 +1,112 @@
+package nz.co.searchwellington.feeds.reading
+
+import com.rabbitmq.client.{CancelCallback, DeliverCallback, Delivery}
+import io.micrometer.core.instrument.MeterRegistry
+import io.opentelemetry.api.trace.Span
+import nz.co.searchwellington.feeds.FeedReader
+import nz.co.searchwellington.model.{Feed, User}
+import nz.co.searchwellington.queues.{RabbitConnectionFactory, ReadFeedQueue}
+import nz.co.searchwellington.repositories.mongo.MongoRepository
+import org.apache.commons.logging.LogFactory
+import org.springframework.beans.factory.annotation.{Autowired, Qualifier}
+import org.springframework.core.task.TaskExecutor
+import org.springframework.stereotype.Component
+import play.api.libs.json.Json
+import reactivemongo.api.bson.BSONObjectID
+
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
+
+@Component class ReadFeedConsumer @Autowired()(rabbitConnectionFactory: RabbitConnectionFactory,
+                                               @Qualifier("feedReaderTaskExecutor") feedReaderTaskExecutor: TaskExecutor,
+                                               feedReader: FeedReader,
+                                               mongoRepository: MongoRepository,
+                                               registry: MeterRegistry) {
+
+  private val log = LogFactory.getLog(classOf[ReadFeedConsumer])
+
+  private val pulledCounter = registry.counter("readfeed_pulled")
+  private val FEED_READER_PROFILE_NAME = "feedreader"
+
+  private val maximumConcurrentChecks = 3
+
+  {
+    log.info("Starting read feed listener")
+    try {
+      val connection = rabbitConnectionFactory.connect
+
+      val channel = connection.createChannel
+      // The consumer immediately dispatches each new message into a Future.
+      // There is no back pressure from the consumer to stop Rabbit flooding us.
+      // So we'll use the Rabbit channel maximum unacked messages / Qos as our flow control.
+      channel.basicQos(maximumConcurrentChecks)
+
+      implicit val executionContext: ExecutionContextExecutor = ExecutionContext.fromExecutor(feedReaderTaskExecutor)
+
+      val deliverCallback: DeliverCallback = (consumerTag: String, message: Delivery) => {
+        implicit val currentSpan: Span = Span.current()
+
+        try {
+          log.info(s"Read feed handling delivery with consumer tag: $consumerTag")
+          pulledCounter.increment()
+          val body = message.getBody
+          val asJson = new String(body)
+          val request = Json.parse(asJson).as[ReadFeedRequest]
+
+          val eventualMaybeFeedReaderUser: Future[Option[User]] = mongoRepository.getUserByProfilename(FEED_READER_PROFILE_NAME)
+          val eventualMaybeFeed = mongoRepository.getResourceByObjectId(BSONObjectID.parse(request.feedId).get).map {
+            case f: Some[Feed] =>
+              f
+            case _ => None
+          }
+
+          val eventualEventualMaybeTuple: Future[Option[(Feed, User)]] = eventualMaybeFeedReaderUser.flatMap { maybeFeedReaderUser =>
+            eventualMaybeFeed.map { maybeFeed =>
+              maybeFeedReaderUser.flatMap { feedReaderUser =>
+                maybeFeed.map { feed =>
+                  (feed, feedReaderUser)
+                }
+              }
+            }
+          }
+
+          val eventualEventualInt: Future[Int] = eventualEventualMaybeTuple.flatMap { maybeTuple =>
+            maybeTuple.map { case (feed, feedReaderUser) =>
+              feedReader.processFeed(feed, feedReaderUser)
+
+            }.getOrElse {
+              log.warn("Failed to find feed or feed reader user")
+              Future.successful(0)
+            }
+          }
+
+
+          eventualEventualInt.map { accepted =>
+            log.info(s"Read feed accepted $accepted items")
+            channel.basicAck(message.getEnvelope.getDeliveryTag, false)
+
+          }.recover {
+            case e: Exception =>
+              log.error("Failed to read feed", e)
+          }
+
+        }
+        catch {
+          case e: Exception =>
+            log.error(s"Failed to handle read feed message", e)
+        }
+      }
+
+      val cancelCallback: CancelCallback = (consumerTag: String) => {
+        log.info(s"Consumer cancelled: $consumerTag")
+      }
+
+      val consumerTag = channel.basicConsume(ReadFeedQueue.QUEUE_NAME, false, deliverCallback, cancelCallback)
+      log.info(s"Read feed consumer created with consumer tag: $consumerTag")
+
+    } catch {
+      case e: Exception =>
+        log.error(e)
+    }
+  }
+
+}

--- a/src/main/scala/nz/co/searchwellington/feeds/reading/ReadFeedRequest.scala
+++ b/src/main/scala/nz/co/searchwellington/feeds/reading/ReadFeedRequest.scala
@@ -1,0 +1,12 @@
+package nz.co.searchwellington.feeds.reading
+
+import play.api.libs.json.{Json, Reads, Writes}
+
+import java.util.Date
+
+case class ReadFeedRequest(feedId: String, lastRead: Option[Date])
+
+object ReadFeedRequest {
+  implicit val r: Reads[ReadFeedRequest] = Json.reads[ReadFeedRequest]
+  implicit val w: Writes[ReadFeedRequest] = Json.writes[ReadFeedRequest]
+}

--- a/src/main/scala/nz/co/searchwellington/jobs/CheckWatchlistsAndLongTail.scala
+++ b/src/main/scala/nz/co/searchwellington/jobs/CheckWatchlistsAndLongTail.scala
@@ -1,7 +1,6 @@
 package nz.co.searchwellington.jobs
 
 import nz.co.searchwellington.ReasonableWaits
-import nz.co.searchwellington.linkchecking.LinkCheckRequest
 import nz.co.searchwellington.model.Resource
 import nz.co.searchwellington.queues.LinkCheckerQueue
 import nz.co.searchwellington.repositories.mongo.MongoRepository

--- a/src/main/scala/nz/co/searchwellington/jobs/ReadFeeds.scala
+++ b/src/main/scala/nz/co/searchwellington/jobs/ReadFeeds.scala
@@ -1,65 +1,35 @@
 package nz.co.searchwellington.jobs
 
-import io.opentelemetry.api.trace.Span
 import nz.co.searchwellington.ReasonableWaits
-import nz.co.searchwellington.feeds.FeedReader
-import nz.co.searchwellington.model.{Feed, User}
+import nz.co.searchwellington.feeds.reading.ReadFeedRequest
+import nz.co.searchwellington.model.Feed
+import nz.co.searchwellington.queues.ReadFeedQueue
 import nz.co.searchwellington.repositories.mongo.MongoRepository
 import org.apache.commons.logging.LogFactory
-import org.joda.time.{DateTime, Duration}
-import org.springframework.beans.factory.annotation.{Autowired, Qualifier}
-import org.springframework.core.task.TaskExecutor
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 
-import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
 
-@Component class ReadFeeds @Autowired()(feedReader: FeedReader,
-                                        mongoRepository: MongoRepository,
-                                        @Qualifier("feedReaderTaskExecutor") feedReaderTaskExecutor: TaskExecutor)
+@Component class ReadFeeds @Autowired()(mongoRepository: MongoRepository,
+                                        readFeedQueue: ReadFeedQueue)
   extends ReasonableWaits {
 
   private val log = LogFactory.getLog(classOf[ReadFeeds])
-  private val FEED_READER_PROFILE_NAME = "feedreader"
 
   @Scheduled(cron = "0 */10 * * * *")
   def readFeeds(): Unit = {
-    implicit val executionContext: ExecutionContextExecutor = ExecutionContext.fromExecutor(feedReaderTaskExecutor)
-    implicit val currentSpan: Span = Span.current()
 
-    def getFeedReaderUser: Future[Option[User]] = mongoRepository.getUserByProfilename(FEED_READER_PROFILE_NAME)
-
-    def readAllFeeds(feeds: Seq[Feed]): Future[Boolean] = {
-      getFeedReaderUser.map { maybyFeedUser =>
-        maybyFeedUser.map { feedReaderUser =>
-          val start = DateTime.now()
-          log.info(s"Reading ${feeds.size} feeds as user ${feedReaderUser.name}")
-          val accepted = feeds.map { feed =>
-            try {
-              Await.result(feedReader.processFeed(feed, feedReaderUser), TenSeconds)
-            } catch {
-              case e: Exception =>
-                log.error("Error reading feed: " + feed, e)
-                0
-            }
-          }.sum
-
-          val duration = new Duration(start, DateTime.now)
-          log.info(s"Accepted $accepted newsitems from ${feeds.size} feeds in ${duration.getStandardSeconds} seconds")
-          true
-
-        }.getOrElse {
-          log.warn("Feed reader could not run as no user was found with profile name: " + FEED_READER_PROFILE_NAME)
-          false
-        }
+    def queueAllFeeds(feeds: Seq[Feed]): Unit = {
+      feeds.foreach { feed =>
+        readFeedQueue.add(ReadFeedRequest(feed._id.stringify, feed.last_read))
       }
     }
 
-    log.info("Running feed reader.")
-    mongoRepository.getAllFeeds().flatMap { feeds =>
-      readAllFeeds(feeds)
-    }.map { _ =>
-      log.info("Finished reading feeds.")
+    log.info("Queuing feeds for reading.")
+    mongoRepository.getAllFeeds().map(queueAllFeeds).map { _ =>
+      log.info("Finished queuing feeds.")
     }
   }
 

--- a/src/main/scala/nz/co/searchwellington/queues/ReadFeedQueue.scala
+++ b/src/main/scala/nz/co/searchwellington/queues/ReadFeedQueue.scala
@@ -1,0 +1,37 @@
+package nz.co.searchwellington.queues
+
+import io.micrometer.core.instrument.MeterRegistry
+import nz.co.searchwellington.feeds.reading.ReadFeedRequest
+import org.apache.commons.logging.LogFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import play.api.libs.json.Json
+
+@Component
+class ReadFeedQueue @Autowired()(val rabbitConnectionFactory: RabbitConnectionFactory, val registry: MeterRegistry) {
+
+  private val log = LogFactory.getLog(classOf[ReadFeedQueue])
+
+  private val channel = rabbitConnectionFactory.connect.createChannel
+  private val queuedCounter = registry.counter("readfeed_queued")
+
+  {
+    channel.queueDeclare(ReadFeedQueue.QUEUE_NAME, false, false, false, null)
+  }
+
+  def add(request: ReadFeedRequest): Unit = try {
+    val asJson = Json.stringify(Json.toJson(request))
+    log.info(s"Adding request to queue: $asJson")
+    channel.basicPublish("", ReadFeedQueue.QUEUE_NAME, null, asJson.getBytes)
+    queuedCounter.increment()
+
+  } catch {
+    case e: Exception =>
+     log.error("Failed to add to read feed queue", e)
+  }
+
+}
+
+object ReadFeedQueue {
+  val QUEUE_NAME: String = "wellynewsreadfeed"
+}


### PR DESCRIPTION
Feed reading moves to Rabbit MQ queue and consumer.

This is mainly distributed systems design interview cosplay.
External queues aren't really needed on this project but want one app which uses them solely for interview fitness.