### PR TITLE
Elastic search index updates go through a queue

### DIFF
--- a/src/main/java/nz/co/searchwellington/Main.java
+++ b/src/main/java/nz/co/searchwellington/Main.java
@@ -71,6 +71,15 @@ public class Main {
         return new DateRegexCommentFeedDetector();
     }
 
+    @Bean("elasticIndexTaskExecutor")
+    public TaskExecutor elasticIndexTaskExecutor() {
+        ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
+        threadPoolTaskExecutor.setCorePoolSize(1);
+        threadPoolTaskExecutor.setMaxPoolSize(2);
+        threadPoolTaskExecutor.setQueueCapacity(50000);
+        return threadPoolTaskExecutor;
+    }
+
     @Bean("feedReaderTaskExecutor")
     public TaskExecutor feedReaderTaskExecutor() {
         ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();

--- a/src/main/scala/nz/co/searchwellington/controllers/EditFeedController.scala
+++ b/src/main/scala/nz/co/searchwellington/controllers/EditFeedController.scala
@@ -122,9 +122,14 @@ class EditFeedController @Autowired()(contentUpdateService: ContentUpdateService
   // Trying to get this generalised
   private def reindexForTagChanges(feed: Feed, updatedFeed: Feed, withUpdatedTags: Resource): Future[Boolean] = {
     // TODO withUpdatedTags is a smell.
-    val tagsHaveChanged = feed.resource_tags.map(_.tag_id).toSet != withUpdatedTags.resource_tags.map(_.tag_id).toSet
-    val publisherHasChanged = feed.publisher != updatedFeed.publisher
-    if (tagsHaveChanged || publisherHasChanged) {
+
+    def changeEffectsChildren: Boolean = {
+      val tagsHaveChanged = feed.resource_tags.map(_.tag_id).toSet != withUpdatedTags.resource_tags.map(_.tag_id).toSet
+      val publisherHasChanged = feed.publisher != updatedFeed.publisher
+      tagsHaveChanged || publisherHasChanged
+    }
+
+    if (changeEffectsChildren) {
       // TODO is the feed url has changed we will need to update Whakaoko
       // This would be easier of the feed knew it's whakaoko subscription id
       mongoRepository.getResourcesIdsAcceptedFrom(feed).flatMap { taggedResourceIds =>

--- a/src/main/scala/nz/co/searchwellington/queues/ElasticIndexQueue.scala
+++ b/src/main/scala/nz/co/searchwellington/queues/ElasticIndexQueue.scala
@@ -7,6 +7,7 @@ import org.apache.commons.logging.LogFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import play.api.libs.json.Json
+import reactivemongo.api.bson.BSONObjectID
 
 @Component
 class ElasticIndexQueue @Autowired()(val rabbitConnectionFactory: RabbitConnectionFactory, val registry: MeterRegistry) {
@@ -22,7 +23,11 @@ class ElasticIndexQueue @Autowired()(val rabbitConnectionFactory: RabbitConnecti
   }
 
   def add(resource: Resource): Boolean = try {
-    val request = ElasticIndexRequest(resourceId = resource._id.stringify)
+    add(resource._id)
+  }
+
+  def add(resourceId: BSONObjectID): Boolean = try {
+    val request = ElasticIndexRequest(resourceId = resourceId.stringify)
     val asJson = Json.stringify(Json.toJson(request))
 
     log.info(s"Adding elastic index request to queue: $asJson")

--- a/src/main/scala/nz/co/searchwellington/queues/ElasticIndexQueue.scala
+++ b/src/main/scala/nz/co/searchwellington/queues/ElasticIndexQueue.scala
@@ -1,0 +1,42 @@
+package nz.co.searchwellington.queues
+
+import io.micrometer.core.instrument.MeterRegistry
+import nz.co.searchwellington.linkchecking.LinkCheckRequest
+import nz.co.searchwellington.model.Resource
+import org.apache.commons.logging.LogFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import play.api.libs.json.Json
+
+@Component
+class ElasticIndexQueue @Autowired()(val rabbitConnectionFactory: RabbitConnectionFactory, val registry: MeterRegistry) {
+  // Try to hide our current use of rabbitmq from the rest of the application
+
+  private val log = LogFactory.getLog(classOf[LinkCheckerQueue])
+
+  private val channel = rabbitConnectionFactory.connect.createChannel
+  private val queuedCounter = registry.counter("elasticindex_queued")
+
+  {
+    channel.queueDeclare(ElasticIndexQueue.QUEUE_NAME, false, false, false, null)
+  }
+
+  def add(resource: Resource): Boolean = try {
+    val request = ElasticIndexRequest(resourceId = resource._id.stringify)
+    val asJson = Json.stringify(Json.toJson(request))
+
+    log.info(s"Adding elastic index request to queue: $asJson")
+    channel.basicPublish("", ElasticIndexQueue.QUEUE_NAME, null, asJson.getBytes)
+    queuedCounter.increment()
+    true
+  } catch {
+    case e: Exception =>
+      log.error("Failed to add to  elastic index queue", e)
+      false
+  }
+
+}
+
+object ElasticIndexQueue {
+  val QUEUE_NAME: String = "wellynewselasticindex"
+}

--- a/src/main/scala/nz/co/searchwellington/queues/ElasticIndexRequest.scala
+++ b/src/main/scala/nz/co/searchwellington/queues/ElasticIndexRequest.scala
@@ -1,0 +1,10 @@
+package nz.co.searchwellington.queues
+
+import play.api.libs.json.{Json, Reads, Writes}
+
+case class ElasticIndexRequest(resourceId: String)
+
+object ElasticIndexRequest {
+  implicit val eirr: Reads[ElasticIndexRequest] = Json.reads[ElasticIndexRequest]
+  implicit val eirw: Writes[ElasticIndexRequest] = Json.writes[ElasticIndexRequest]
+}

--- a/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticIndexConsumer.scala
+++ b/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticIndexConsumer.scala
@@ -1,0 +1,90 @@
+package nz.co.searchwellington.repositories.elasticsearch
+
+import com.rabbitmq.client.{CancelCallback, Channel, DeliverCallback, Delivery}
+import io.micrometer.core.instrument.MeterRegistry
+import nz.co.searchwellington.queues.{ElasticIndexQueue, ElasticIndexRequest, RabbitConnectionFactory}
+import org.apache.commons.logging.LogFactory
+import org.springframework.beans.factory.annotation.{Autowired, Qualifier}
+import org.springframework.core.task.TaskExecutor
+import org.springframework.stereotype.Component
+import play.api.libs.json.Json
+import reactivemongo.api.bson.BSONObjectID
+
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
+
+@Component
+class ElasticIndexConsumer @Autowired()(elasticSearchIndexRebuildService: ElasticSearchIndexRebuildService,
+                                        rabbitConnectionFactory: RabbitConnectionFactory,
+                                        @Qualifier("elasticIndexTaskExecutor") taskExecutor: TaskExecutor,
+                                        registry: MeterRegistry) {
+
+  private val log = LogFactory.getLog(classOf[ElasticIndexConsumer])
+
+  private val pulledCounter = registry.counter("elasticindex_pulled")
+
+  private val maximumConcurrentChecks = 1
+
+  {
+    log.info("Starting elastic index listener")
+    try {
+      val connection = rabbitConnectionFactory.connect
+
+      val channel = connection.createChannel
+      // The consumer immediately dispatches each new message into a Future.
+      // There is no back pressure from the consumer to stop Rabbit flooding us.
+      // So we'll use the Rabbit channel maximum unacked messages / Qos as our flow control.
+      channel.basicQos(maximumConcurrentChecks)
+
+      implicit val executionContext: ExecutionContextExecutor = ExecutionContext.fromExecutor(taskExecutor)
+
+      val deliverCallback: DeliverCallback = (consumerTag: String, message: Delivery) => {
+        try {
+          log.debug(s"Elastic index handling delivery with consumer tag: $consumerTag")
+          pulledCounter.increment()
+          val body = message.getBody
+          val asJson = new String(body)
+          val request = Json.parse(asJson).as[ElasticIndexRequest]
+
+          val resourceId = BSONObjectID.parse(request.resourceId).get
+
+          val toIndex = Seq(resourceId)
+          elasticSearchIndexRebuildService.reindexResources(resourcesToIndex = toIndex, totalResources = toIndex.size).map { r: Int =>
+            channel.basicAck(message.getEnvelope.getDeliveryTag, false)
+            logQueueCount(channel)
+
+          }.recover {
+            case e: Throwable => log.error(s"Index future failed; ignoring and acking", e)
+            channel.basicAck(message.getEnvelope.getDeliveryTag, false)
+          }
+
+        } catch {
+          case e: Exception =>
+            log.error("Error while processing elastic index message; ignoring and acking", e)
+            channel.basicAck(message.getEnvelope.getDeliveryTag, false)
+        }
+      }
+
+      val cancelCallback: CancelCallback = (consumerTag: String) => {
+        log.info(s"Consumer cancelled: $consumerTag")
+      }
+
+      val consumerTag = channel.basicConsume(ElasticIndexQueue.QUEUE_NAME, false, deliverCallback, cancelCallback)
+      log.info(s"Elastic index consumer created with consumer tag: $consumerTag")
+
+    } catch {
+      case e: Exception =>
+        log.error("Failed to start elastic index listener", e)
+    }
+  }
+
+  private def logQueueCount(channel: Channel): Unit = {
+    try {
+      val countFromChannel = channel.messageCount(ElasticIndexQueue.QUEUE_NAME)
+      log.info(s"Elastic index channel contains $countFromChannel ready to deliver messages")
+    } catch {
+      case e: Exception =>
+        log.error("Error while counting messages: ", e)
+    }
+  }
+
+}

--- a/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticSearchIndexRebuildService.scala
+++ b/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticSearchIndexRebuildService.scala
@@ -1,9 +1,6 @@
 package nz.co.searchwellington.repositories.elasticsearch
 
-import com.sksamuel.elastic4s.Response
-import com.sksamuel.elastic4s.requests.bulk.BulkResponse
 import nz.co.searchwellington.ReasonableWaits
-import nz.co.searchwellington.model.Resource
 import nz.co.searchwellington.repositories.mongo.MongoRepository
 import nz.co.searchwellington.tagging.IndexTagsService
 import nz.co.searchwellington.urls.UrlParser
@@ -24,15 +21,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
   private val BATCH_COMMIT_SIZE = 100
 
-  def index(resource: Resource)(implicit ec: ExecutionContext): Future[Boolean] = {
-    toIndexable(resource).flatMap { toIndex =>
-      elasticSearchIndexer.updateMultipleContentItems(Seq(toIndex))
-    }.map { r: Response[BulkResponse] =>
-      !r.result.hasFailures
-    }
-  }
-
-  def reindexResources(resourcesToIndex: Seq[BSONObjectID], i: Int = 0, totalResources: Int)(implicit ec: ExecutionContext): Future[Int] = {
+  protected[elasticsearch] def reindexResources(resourcesToIndex: Seq[BSONObjectID], i: Int = 0, totalResources: Int)(implicit ec: ExecutionContext): Future[Int] = {
     val remaining = resourcesToIndex.size
 
     def indexBatch(batch: Seq[BSONObjectID], i: Int): Future[Int] = {

--- a/src/test/scala/nz/co/searchwellington/controllers/ContentUpdateServiceTest.scala
+++ b/src/test/scala/nz/co/searchwellington/controllers/ContentUpdateServiceTest.scala
@@ -1,38 +1,36 @@
 package nz.co.searchwellington.controllers
 
-import java.util.UUID
 import nz.co.searchwellington.ReasonableWaits
-import nz.co.searchwellington.linkchecking.LinkCheckRequest
 import nz.co.searchwellington.model.{Newsitem, Website}
 import nz.co.searchwellington.modification.ContentUpdateService
-import nz.co.searchwellington.queues.LinkCheckerQueue
-import nz.co.searchwellington.repositories.elasticsearch.ElasticSearchIndexRebuildService
+import nz.co.searchwellington.queues.{ElasticIndexQueue, LinkCheckerQueue}
 import nz.co.searchwellington.repositories.mongo.MongoRepository
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.{mock, verify, when}
 import reactivemongo.api.commands.WriteResult
 
+import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{Await, Future}
 
 class ContentUpdateServiceTest extends ReasonableWaits {
 
   private val mongoRepository = mock(classOf[MongoRepository])
-  private val elasticSearchIndexRebuildService = mock(classOf[ElasticSearchIndexRebuildService])
+  private val elasticIndexQueue = mock(classOf[ElasticIndexQueue])
   private val linkCheckerQueue = mock(classOf[LinkCheckerQueue])
 
   private val resourceId = UUID.randomUUID().toString
   private val updatedResource = Newsitem(id = resourceId, page = "http://test/123")
 
-  private val service = new ContentUpdateService(mongoRepository, elasticSearchIndexRebuildService, linkCheckerQueue)
+  private val service = new ContentUpdateService(mongoRepository, elasticIndexQueue, linkCheckerQueue)
   private val successfulUpdateResult = mock(classOf[WriteResult])
 
   @Test
   def shouldPersistUpdatesInMongo(): Unit = {
     when(mongoRepository.getResourceByObjectId(updatedResource._id)).thenReturn(Future.successful(None))
     when(mongoRepository.saveResource(updatedResource)).thenReturn(Future.successful(successfulUpdateResult))
-    when(elasticSearchIndexRebuildService.index(updatedResource)).thenReturn(Future.successful(true))
+    when(elasticIndexQueue.add(updatedResource)).thenReturn(true)
 
     Await.result(service.update(updatedResource), TenSeconds)
 
@@ -43,18 +41,18 @@ class ContentUpdateServiceTest extends ReasonableWaits {
   def shouldUpdateTheElasticsearchIndexWhenUpdating(): Unit = {
     when(mongoRepository.getResourceByObjectId(updatedResource._id)).thenReturn(Future.successful(None))
     when(mongoRepository.saveResource(updatedResource)).thenReturn(Future.successful(successfulUpdateResult))
-    when(elasticSearchIndexRebuildService.index(updatedResource)).thenReturn(Future.successful(true))
+    when(elasticIndexQueue.add(updatedResource)).thenReturn(true)
 
     Await.result(service.update(updatedResource), TenSeconds)
 
-    verify(elasticSearchIndexRebuildService).index(updatedResource)
+    verify(elasticIndexQueue).add(updatedResource)
   }
 
   @Test
   def shouldQueueNewlyCreatedResourcesForLinkChecking(): Unit = {
     val newResource = Website()
     when(mongoRepository.saveResource(newResource)).thenReturn(Future.successful(successfulUpdateResult))
-    when(elasticSearchIndexRebuildService.index(newResource)).thenReturn(Future.successful(true))
+    when(elasticIndexQueue.add(newResource)).thenReturn(true)
     when(successfulUpdateResult.writeErrors).thenReturn(Seq.empty)
 
     Await.result(service.create(newResource), TenSeconds)
@@ -68,7 +66,7 @@ class ContentUpdateServiceTest extends ReasonableWaits {
     val updatedResource = resource.copy(page = "http://localhost/new-url")
     when(mongoRepository.getResourceByObjectId(updatedResource._id)).thenReturn(Future.successful(Some(resource)))
     when(mongoRepository.saveResource(updatedResource)).thenReturn(Future.successful(successfulUpdateResult))
-    when(elasticSearchIndexRebuildService.index(updatedResource)).thenReturn(Future.successful(true))
+    when(elasticIndexQueue.add(updatedResource)).thenReturn(true)
     when(successfulUpdateResult.writeErrors).thenReturn(Seq.empty)
 
     Await.result(service.update(updatedResource), TenSeconds)

--- a/src/test/scala/nz/co/searchwellington/modification/TagModificationServiceTest.scala
+++ b/src/test/scala/nz/co/searchwellington/modification/TagModificationServiceTest.scala
@@ -1,18 +1,18 @@
 package nz.co.searchwellington.modification
 
+import nz.co.searchwellington.ReasonableWaits
 import nz.co.searchwellington.model.geo.Geocode
 import nz.co.searchwellington.model.{Newsitem, Tag}
 import nz.co.searchwellington.queues.ElasticIndexQueue
-import nz.co.searchwellington.repositories.elasticsearch.ElasticSearchIndexRebuildService
 import nz.co.searchwellington.repositories.mongo.MongoRepository
 import nz.co.searchwellington.repositories.{HandTaggingService, TagDAO}
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.{mock, verify, when}
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{Await, Future}
 
-class TagModificationServiceTest {
+class TagModificationServiceTest extends ReasonableWaits {
 
   private val tagDAO = mock(classOf[TagDAO])
   private val handTaggingService = mock(classOf[HandTaggingService])
@@ -50,7 +50,7 @@ class TagModificationServiceTest {
 
     when(mongoRepository.getResourceIdsByTag(tag)).thenReturn(Future.successful(Seq(taggedResource._id)))
 
-    tagModificationService.updateAffectedResources(tag, updatedWithGeocode)
+    Await.result(tagModificationService.updateAffectedResources(tag, updatedWithGeocode), TenSeconds)
 
     verify(elasticIndexQueue).add(taggedResource._id)
   }


### PR DESCRIPTION
Just systems design cosplay.
Send all Elastic search update requests out via a RabbitMQ rather than a local Future purely so that we can say distributed system.

Interesting batching problem; the consumer should pool messages into batches to replicate the performance of the old Futures updater.