### PR TITLE
Promotion of recently accepted news items

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,18 @@ Relevant items which can be manually accepted using the accept action.
 ![Feeds inbox](docs/feeds-inbox.png)
 
 
+### Promotion of recently accepted news items
+
+The main news items page and RSS feed contains the most recent 30 news items ordered by publication date.
+
+Reviewing the suggested feeds items is an infrequent activity and good content may mess out on been surfaced in the main feed
+if it's publication date is not recent.
+
+If a news items is manually accepted from a suggested feed and has a publication date which is not recent enough
+to show in the main feed and is within the last 2 weeks it will be appended to the main feed for 1 day.
+
+This makes manually accepted content visible to feed consumers.
+
 
 ### RSS output
 

--- a/src/main/scala/nz/co/searchwellington/controllers/models/helpers/IndexModelBuilder.scala
+++ b/src/main/scala/nz/co/searchwellington/controllers/models/helpers/IndexModelBuilder.scala
@@ -39,7 +39,9 @@ import scala.jdk.CollectionConverters._
       latestNewsitems <- eventualLatestNewsitems
       recentlyAccepted <- eventualRecentlyAccepted
     } yield {
-      val recentlyAcceptedToPromote = recentlyAccepted._1.filterNot(latestNewsitems.contains)
+      val recentlyAcceptedToPromote = recentlyAccepted._1.filterNot(latestNewsitems.contains).filter { fni =>
+        fni.date.exists(_.after(DateTime.now().minusWeeks(2).toDate)) // TODO push to query
+      }
       val mainNewsitems = latestNewsitems ++ recentlyAcceptedToPromote
 
       val mv = new ModelMap().

--- a/src/main/scala/nz/co/searchwellington/repositories/ContentRetrievalService.scala
+++ b/src/main/scala/nz/co/searchwellington/repositories/ContentRetrievalService.scala
@@ -229,8 +229,8 @@ import scala.concurrent.{ExecutionContext, Future}
     elasticSearchIndexer.getResources(latestWebsites, loggedInUser = loggedInUser).flatMap(r => buildFrontendResourcesFor(r, loggedInUser))
   }
 
-  def getAcceptedNewsitems(maxItems: Int, loggedInUser: Option[User], acceptedDate: Option[LocalDate] = None, acceptedAfter: Option[DateTime] = None)(implicit ec: ExecutionContext, currentSpan: Span): Future[(Seq[FrontendResource], Long)] = {
-    val acceptedNewsitems = ResourceQuery(`type` = newsitems, maxItems = maxItems, acceptedDate = acceptedDate, acceptedAfter = acceptedAfter)
+  def getAcceptedNewsitems(maxItems: Int, loggedInUser: Option[User], acceptedDate: Option[LocalDate] = None, acceptedAfter: Option[DateTime] = None, publishedAfter: Option[DateTime] = None)(implicit ec: ExecutionContext, currentSpan: Span): Future[(Seq[FrontendResource], Long)] = {
+    val acceptedNewsitems = ResourceQuery(`type` = newsitems, maxItems = maxItems, acceptedDate = acceptedDate, acceptedAfter = acceptedAfter, after = publishedAfter)
     elasticSearchIndexer.getResources(acceptedNewsitems, elasticSearchIndexer.byAcceptedDate, loggedInUser = loggedInUser).flatMap(r => buildFrontendResourcesFor(r, loggedInUser))
   }
 

--- a/src/main/scala/nz/co/searchwellington/repositories/ContentRetrievalService.scala
+++ b/src/main/scala/nz/co/searchwellington/repositories/ContentRetrievalService.scala
@@ -229,9 +229,9 @@ import scala.concurrent.{ExecutionContext, Future}
     elasticSearchIndexer.getResources(latestWebsites, loggedInUser = loggedInUser).flatMap(r => buildFrontendResourcesFor(r, loggedInUser))
   }
 
-  def getAcceptedNewsitems(maxItems: Int, loggedInUser: Option[User], acceptedDate: Option[LocalDate] = None)(implicit ec: ExecutionContext, currentSpan: Span): Future[(Seq[FrontendResource], Long)] = {
-    val acceptNewsitems = ResourceQuery(`type` = newsitems, maxItems = maxItems, acceptedDate = acceptedDate) // TODO needs not null clause
-    elasticSearchIndexer.getResources(acceptNewsitems, elasticSearchIndexer.byAcceptedDate, loggedInUser = loggedInUser).flatMap(r => buildFrontendResourcesFor(r, loggedInUser))
+  def getAcceptedNewsitems(maxItems: Int, loggedInUser: Option[User], acceptedDate: Option[LocalDate] = None, acceptedAfter: Option[DateTime] = None)(implicit ec: ExecutionContext, currentSpan: Span): Future[(Seq[FrontendResource], Long)] = {
+    val acceptedNewsitems = ResourceQuery(`type` = newsitems, maxItems = maxItems, acceptedDate = acceptedDate, acceptedAfter = acceptedAfter)
+    elasticSearchIndexer.getResources(acceptedNewsitems, elasticSearchIndexer.byAcceptedDate, loggedInUser = loggedInUser).flatMap(r => buildFrontendResourcesFor(r, loggedInUser))
   }
 
   def getOwnedBy(user: User, loggedInUser: Option[User], maxItems: Int)(implicit ec: ExecutionContext, currentSpan: Span): Future[(Seq[FrontendResource], Long)] = {
@@ -264,7 +264,7 @@ import scala.concurrent.{ExecutionContext, Future}
   }
 
   def getAcceptedDates(loggedInUser: Option[User])(implicit ec: ExecutionContext, currentSpan: Span): Future[Seq[(java.time.LocalDate, Long)]] = {
-      val twoWeeksAgo = DateTime.now.toLocalDate.minusWeeks(2)
+      val twoWeeksAgo = DateTime.now.toLocalDate.minusWeeks(2).toDateTimeAtStartOfDay
       val allNewsitemsAcceptedInTheLastTwoWeeks = allNewsitems.copy(acceptedAfter = Some(twoWeeksAgo))
       elasticSearchIndexer.createdAcceptedDateAggregationFor(allNewsitemsAcceptedInTheLastTwoWeeks, loggedInUser)
   }

--- a/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticSearchIndexer.scala
+++ b/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticSearchIndexer.scala
@@ -382,9 +382,8 @@ class ElasticSearchIndexer @Autowired()(val showBrokenDecisionService: ShowBroke
         val asInterval = a.toInterval() // TODO probably want to make this parameter an Interval to push the timezone decision up
         rangeQuery(AcceptedDate) gte asInterval.getStartMillis lt asInterval.getEndMillis
       },
-      query.acceptedAfter.map { a: LocalDate =>
-        val asInterval = a.toInterval() // TODO probably want to make this parameter an Interval to push the timezone decision up
-        rangeQuery(AcceptedDate) gte asInterval.getStartMillis
+      query.acceptedAfter.map { a: DateTime =>
+        rangeQuery(AcceptedDate) gte a.getMillis
       },
       query.q.map { qt =>
         val titleMatches = matchQuery(Title, qt).boost(5)

--- a/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticSearchIndexer.scala
+++ b/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ElasticSearchIndexer.scala
@@ -378,6 +378,9 @@ class ElasticSearchIndexer @Autowired()(val showBrokenDecisionService: ShowBroke
       query.before.map { d =>
         rangeQuery(Date) lt d.getMillis
       },
+      query.after.map { d =>
+        rangeQuery(Date) gt d.getMillis
+      },
       query.acceptedDate.map { a: LocalDate =>
         val asInterval = a.toInterval() // TODO probably want to make this parameter an Interval to push the timezone decision up
         rangeQuery(AcceptedDate) gte asInterval.getStartMillis lt asInterval.getEndMillis

--- a/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ResourceQuery.scala
+++ b/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ResourceQuery.scala
@@ -22,7 +22,7 @@ case class ResourceQuery(`type`: Option[Set[String]] = None,
                          before: Option[DateTime] = None,
                          notPublishedBy: Option[Website] = None,
                          acceptedDate: Option[LocalDate] = None,
-                         acceptedAfter: Option[LocalDate] = None
+                         acceptedAfter: Option[DateTime] = None
                         )
 
 case class Circle(centre: LatLong, radius: Double)

--- a/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ResourceQuery.scala
+++ b/src/main/scala/nz/co/searchwellington/repositories/elasticsearch/ResourceQuery.scala
@@ -22,7 +22,8 @@ case class ResourceQuery(`type`: Option[Set[String]] = None,
                          before: Option[DateTime] = None,
                          notPublishedBy: Option[Website] = None,
                          acceptedDate: Option[LocalDate] = None,
-                         acceptedAfter: Option[DateTime] = None
+                         acceptedAfter: Option[DateTime] = None,
+                         after: Option[DateTime] = None
                         )
 
 case class Circle(centre: LatLong, radius: Double)

--- a/src/test/scala/nz/co/searchwellington/controllers/models/helpers/IndexModelBuilderTest.scala
+++ b/src/test/scala/nz/co/searchwellington/controllers/models/helpers/IndexModelBuilderTest.scala
@@ -2,7 +2,7 @@ package nz.co.searchwellington.controllers.models.helpers
 
 import io.opentelemetry.api.trace.Span
 import nz.co.searchwellington.ReasonableWaits
-import nz.co.searchwellington.model.frontend.FrontendNewsitem
+import nz.co.searchwellington.model.frontend.{FrontendNewsitem, FrontendResource}
 import nz.co.searchwellington.model.helpers.ArchiveLinksService
 import nz.co.searchwellington.repositories.ContentRetrievalService
 import nz.co.searchwellington.urls.{RssUrlBuilder, UrlBuilder}
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.{mock, when}
 import org.springframework.mock.web.MockHttpServletRequest
 
+import java.util
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{Await, Future}
 import scala.jdk.CollectionConverters._
@@ -30,6 +31,11 @@ class IndexModelBuilderTest extends ReasonableWaits with ContentFields {
     request
   }
 
+  private val latestNewsitems = {
+    Range.inclusive(1, 30).map { i =>
+      FrontendNewsitem(id = i.toString, name = s"Newsitem title $i", date = Some(DateTime.now.minusHours(i).toDate))
+    }
+  }
 
   private val loggedInUser = None
 
@@ -56,17 +62,24 @@ class IndexModelBuilderTest extends ReasonableWaits with ContentFields {
 
   @Test
   def indexPageMainContentIsTheLatestNewsitems(): Unit = {
-    val latestNewsitems = {
-      Range.inclusive(1, 30).map { i =>
-        FrontendNewsitem(id = i.toString, name = s"Newsitem title $i", date = Some(DateTime.now.minusDays(i).toDate))
-      }
-    }
-
     when(contentRetrievalService.getLatestNewsitems(30, loggedInUser)).thenReturn(Future.successful(latestNewsitems))
 
     val mv = Await.result(modelBuilder.populateContentModel(request), TenSeconds).get
 
     assertEquals(latestNewsitems.asJava, mv.get(MAIN_CONTENT))
+  }
+
+  @Test
+  def recentlyAcceptedItemsLessThanOneWeekOldArePrioritisedSoThatTheyArePickedUpByFeedReaders(): Unit = {
+    val recentlyAcceptedItem = FrontendNewsitem(id = "123", name = s"Recently accepted but older publication date",
+      date = Some(new DateTime(latestNewsitems.last.date.get).minusDays(1).toDate), accepted = Some(DateTime.now.toDate))
+
+    when(contentRetrievalService.getLatestNewsitems(30, loggedInUser)).thenReturn(Future.successful(latestNewsitems))
+
+    val mv = Await.result(modelBuilder.populateContentModel(request), TenSeconds).get
+
+    val mainContent = mv.get(MAIN_CONTENT).asInstanceOf[util.List[FrontendResource]].asScala.toSeq
+    assertTrue(mainContent.contains(recentlyAcceptedItem))
   }
 
 }

--- a/src/test/scala/nz/co/searchwellington/controllers/models/helpers/IndexModelBuilderTest.scala
+++ b/src/test/scala/nz/co/searchwellington/controllers/models/helpers/IndexModelBuilderTest.scala
@@ -69,7 +69,9 @@ class IndexModelBuilderTest extends ReasonableWaits with ContentFields {
       ArgumentMatchers.eq(30),
       ArgumentMatchers.eq(loggedInUser),
       ArgumentMatchers.eq(None),
-      ArgumentMatchers.any())(any, any)).
+      ArgumentMatchers.any(),
+      ArgumentMatchers.any()
+    )(any, any)).
       thenReturn(Future.successful((Seq.empty, 0L)))
     val mv = Await.result(modelBuilder.populateContentModel(request), TenSeconds).get
 
@@ -85,7 +87,9 @@ class IndexModelBuilderTest extends ReasonableWaits with ContentFields {
       ArgumentMatchers.eq(30),
       ArgumentMatchers.eq(loggedInUser),
       ArgumentMatchers.eq(None),
-      ArgumentMatchers.any())(any, any)).
+      ArgumentMatchers.any(), // TODO assert
+      ArgumentMatchers.any()  // TODO assert
+    )(any, any)).
       thenReturn(Future.successful((Seq(recentlyAcceptedItem), 1L)))
 
     when(contentRetrievalService.getLatestNewsitems(30, loggedInUser)).thenReturn(Future.successful(latestNewsitems))

--- a/src/test/scala/nz/co/searchwellington/controllers/models/helpers/IndexModelBuilderTest.scala
+++ b/src/test/scala/nz/co/searchwellington/controllers/models/helpers/IndexModelBuilderTest.scala
@@ -30,9 +30,6 @@ class IndexModelBuilderTest extends ReasonableWaits with ContentFields {
     request
   }
 
-  private val newsitem = FrontendNewsitem(id = "123", name = "Newsitem title", date =Some(DateTime.now.toDate))
-  private val anotherNewsitem = FrontendNewsitem(id = "456", name = "Newsitem title", date =Some(DateTime.now.toDate))
-  private val latestNewsitems = Seq(newsitem, anotherNewsitem)
 
   private val loggedInUser = None
 
@@ -59,6 +56,12 @@ class IndexModelBuilderTest extends ReasonableWaits with ContentFields {
 
   @Test
   def indexPageMainContentIsTheLatestNewsitems(): Unit = {
+    val latestNewsitems = {
+      Range.inclusive(1, 30).map { i =>
+        FrontendNewsitem(id = i.toString, name = s"Newsitem title $i", date = Some(DateTime.now.minusDays(i).toDate))
+      }
+    }
+
     when(contentRetrievalService.getLatestNewsitems(30, loggedInUser)).thenReturn(Future.successful(latestNewsitems))
 
     val mv = Await.result(modelBuilder.populateContentModel(request), TenSeconds).get


### PR DESCRIPTION
The main news items page and RSS feed contains the most recent 30 news items ordered by publication date.

Reviewing the suggested feeds items is an infrequent activity and good content may mess out on been surfaced in the main feed
if it's publication date is not recent.

If a news items is manually accepted from a suggested feed and has a publication date which is not recent enough
to show in the main feed and is within the last 2 weeks it will be appended to the main feed for 1 day.

This makes manually accepted content visible to feed consumers.